### PR TITLE
fix(windows): force_topology_extend always fails with ERROR_INVALID_PARAMETER (87)

### DIFF
--- a/src-tauri/src/backend/windows/apply.rs
+++ b/src-tauri/src/backend/windows/apply.rs
@@ -16,8 +16,8 @@ use windows::Win32::Devices::Display::{
     DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME, DISPLAYCONFIG_DEVICE_INFO_HEADER,
     DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO, DISPLAYCONFIG_MODE_INFO, DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE,
     DISPLAYCONFIG_PATH_INFO, DISPLAYCONFIG_SOURCE_DEVICE_NAME, DISPLAYCONFIG_TARGET_DEVICE_NAME,
-    SDC_ALLOW_CHANGES, SDC_APPLY, SDC_NO_OPTIMIZATION, SDC_SAVE_TO_DATABASE, SDC_TOPOLOGY_EXTEND,
-    SDC_USE_SUPPLIED_DISPLAY_CONFIG,
+    SDC_ALLOW_CHANGES, SDC_APPLY, SDC_NO_OPTIMIZATION, SDC_PATH_PERSIST_IF_REQUIRED,
+    SDC_SAVE_TO_DATABASE, SDC_TOPOLOGY_EXTEND, SDC_USE_SUPPLIED_DISPLAY_CONFIG,
 };
 use windows::Win32::Graphics::Gdi::{CreateDCW, DeleteDC};
 use windows::Win32::System::Com::{
@@ -110,20 +110,41 @@ pub fn apply_layout_against_snapshot(
 }
 
 pub(super) fn force_topology_extend() -> Result<(), ManagerError> {
+    // Flag rules for the SDC_TOPOLOGY_* family, verified with SDC_VALIDATE probes (VALIDATE
+    // applies nothing, so the status is pure flag validation):
+    //
+    //   VALIDATE | TOPOLOGY_EXTEND | ALLOW_CHANGES | SAVE_TO_DATABASE -> 87
+    //   VALIDATE | TOPOLOGY_EXTEND | ALLOW_CHANGES | PATH_PERSIST     -> 87
+    //   VALIDATE | TOPOLOGY_EXTEND | ALLOW_CHANGES                    -> 87
+    //   VALIDATE | TOPOLOGY_EXTEND | PATH_PERSIST                     ->  0 or driver status
+    //   VALIDATE | TOPOLOGY_EXTEND                                    ->  0 or driver status
+    //   VALIDATE | TOPOLOGY_CLONE  | ALLOW_CHANGES                    -> 87
+    //   VALIDATE | TOPOLOGY_CLONE                                     ->  0 or driver status
+    //
+    // Two flags must stay out:
+    //   - SDC_SAVE_TO_DATABASE: documented as "can only be set with
+    //     SDC_USE_SUPPLIED_DISPLAY_CONFIG", which in turn "cannot be set with any
+    //     SDC_TOPOLOGY_XXX flag" -- so it is invalid here by construction.
+    //   - SDC_ALLOW_CHANGES: rejected with every SDC_TOPOLOGY_* flag in practice, even though
+    //     the docs claim it "is allowed with any other valid combination". Trust the probe.
+    //
+    // SDC_PATH_PERSIST_IF_REQUIRED replaces them: a target detached through CCD has its path
+    // persistence turned off, and the extend only considers persisted targets. This flag is
+    // documented to "force path persistence on a target to satisfy the request if necessary",
+    // and is legal with SDC_TOPOLOGY_* (it is only barred from SDC_USE_SUPPLIED_DISPLAY_CONFIG
+    // and SDC_TOPOLOGY_SUPPLIED).
     let set_display_status = unsafe {
         SetDisplayConfig(
             None,
             None,
-            SDC_APPLY | SDC_TOPOLOGY_EXTEND | SDC_ALLOW_CHANGES | SDC_SAVE_TO_DATABASE,
+            SDC_APPLY | SDC_TOPOLOGY_EXTEND | SDC_PATH_PERSIST_IF_REQUIRED,
         )
     };
     if set_display_status == 0 {
         return Ok(());
     }
 
-    // Some driver stacks reject direct topology-extend through SetDisplayConfig during
-    // early-login / post-reboot states. Win+P still succeeds there, so fall back to the same
-    // shell path via DisplaySwitch.
+    // Fall back to the same shell path Win+P uses.
     let display_switch_status = Command::new("DisplaySwitch.exe")
         .creation_flags(CREATE_NO_WINDOW)
         .arg("/extend")

--- a/tools/probe-sdc-flags.ps1
+++ b/tools/probe-sdc-flags.ps1
@@ -1,0 +1,63 @@
+# Probes which SetDisplayConfig flag combinations Windows accepts.
+#
+# Every call uses SDC_VALIDATE instead of SDC_APPLY, so nothing is applied and no display
+# changes: the return value is pure flag validation. Run it on any Windows machine, with any
+# number of monitors, to reproduce the results quoted in force_topology_extend (apply.rs).
+#
+#   0  = the combination is legal (and the request is satisfiable)
+#   87 = ERROR_INVALID_PARAMETER, i.e. "the combination of parameters and flags is invalid"
+#   31 = ERROR_GEN_FAILURE, i.e. flags accepted, but the driver/hardware cannot satisfy it
+#        (expected on a single-display machine: there is nothing to extend onto)
+#
+# The point of interest: 87 means the flags never reached the driver, so it is machine- and
+# driver-independent. It fails the same way everywhere.
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public static class SdcProbe {
+    [DllImport("user32.dll")]
+    public static extern int SetDisplayConfig(
+        uint numPathArrayElements, IntPtr pathArray,
+        uint numModeInfoArrayElements, IntPtr modeInfoArray,
+        uint flags);
+}
+"@
+
+$VALIDATE     = 0x40    # SDC_VALIDATE           - applies nothing
+$EXTEND       = 0x04    # SDC_TOPOLOGY_EXTEND
+$CLONE        = 0x02    # SDC_TOPOLOGY_CLONE
+$ALLOW        = 0x400   # SDC_ALLOW_CHANGES
+$SAVE_DB      = 0x200   # SDC_SAVE_TO_DATABASE
+$PERSIST      = 0x800   # SDC_PATH_PERSIST_IF_REQUIRED
+
+function Probe($label, $flags) {
+    $status = [SdcProbe]::SetDisplayConfig(0, [IntPtr]::Zero, 0, [IntPtr]::Zero, $flags)
+    $meaning = switch ($status) {
+        0     { "OK          - flags legal" }
+        87    { "ILLEGAL     - ERROR_INVALID_PARAMETER (rejected at flag validation)" }
+        31    { "flags legal - ERROR_GEN_FAILURE (driver/hardware cannot satisfy it)" }
+        1168  { "flags legal - ERROR_NOT_FOUND (no such entry in the database)" }
+        default { "status $status" }
+    }
+    "{0,-56} mask={1,-5} -> {2,-4} {3}" -f $label, $flags, $status, $meaning
+}
+
+Write-Output ""
+Write-Output "Current code in force_topology_extend:"
+Probe "VALIDATE|EXTEND|ALLOW_CHANGES|SAVE_TO_DATABASE" ($VALIDATE -bor $EXTEND -bor $ALLOW -bor $SAVE_DB)
+
+Write-Output ""
+Write-Output "Removing one flag at a time:"
+Probe "VALIDATE|EXTEND|ALLOW_CHANGES|PATH_PERSIST"     ($VALIDATE -bor $EXTEND -bor $ALLOW -bor $PERSIST)
+Probe "VALIDATE|EXTEND|ALLOW_CHANGES"                  ($VALIDATE -bor $EXTEND -bor $ALLOW)
+Probe "VALIDATE|EXTEND|PATH_PERSIST   (proposed fix)"  ($VALIDATE -bor $EXTEND -bor $PERSIST)
+Probe "VALIDATE|EXTEND"                                ($VALIDATE -bor $EXTEND)
+
+Write-Output ""
+Write-Output "SDC_ALLOW_CHANGES is the surprise - it is rejected with every SDC_TOPOLOGY_* flag,"
+Write-Output "although the docs say it 'is allowed with any other valid combination':"
+Probe "VALIDATE|CLONE|ALLOW_CHANGES"                   ($VALIDATE -bor $CLONE -bor $ALLOW)
+Probe "VALIDATE|CLONE"                                 ($VALIDATE -bor $CLONE)
+Probe "VALIDATE|CLONE|PATH_PERSIST"                    ($VALIDATE -bor $CLONE -bor $PERSIST)
+Write-Output ""


### PR DESCRIPTION
`force_topology_extend()` can never succeed: the flag combination it passes to `SetDisplayConfig` is invalid, so the call is rejected with `87` (`ERROR_INVALID_PARAMETER`) at flag validation, before it ever reaches the driver. I measured this on the two machines I have: a single-display laptop and a 3-display desktop. I believe it fails identically everywhere, but that is an inference, not a measurement -- what supports it is the probe differential below: EXTEND|ALLOW returns 87 while EXTEND alone returns 31, and only a request that *was* evaluated against the hardware can return 31. So the 87 looks like a parameter-level rejection that never reaches the driver, which would make it hardware-independent.

This is the recovery path that is supposed to rescue an attach when a display has no path in the snapshot, so in practice there is no such rescue today. It looks related to #15 / #40 / #41.

### Evidence

From a user's log (a TV detached before an app restart, then a profile re-attaching it):

```
recover:extend_attempt:'Smart TV Pro' (target_id=4352, ...)
apply:sdc_failed:87:topology_extend
recover:settle_poll:1..14:missing=1
recover:still_missing:'Smart TV Pro' (target_id=4352, ...)
```

(the log lines are from my fork's diagnostics, not from this branch)

I added `tools/probe-sdc-flags.ps1` so this can be checked directly. It probes each combination with `SDC_VALIDATE` instead of `SDC_APPLY`, so **it applies nothing and changes no displays** — the status is pure flag validation. On my machine:

| Flags (with `SDC_VALIDATE`) | Status |
|---|---|
| `EXTEND \| ALLOW_CHANGES \| SAVE_TO_DATABASE` ← current code | **87** |
| `EXTEND \| ALLOW_CHANGES \| PATH_PERSIST` | **87** |
| `EXTEND \| ALLOW_CHANGES` | **87** |
| `EXTEND \| PATH_PERSIST` | 31 |
| `EXTEND` | 31 |
| `CLONE \| ALLOW_CHANGES` | **87** |
| `CLONE` | 31 |

`31` is `ERROR_GEN_FAILURE` on a single-display machine — flags accepted, nothing to extend onto. Anything other than `87` means the flags reached the driver.

### Why

Two flags cannot be there:

- **`SDC_SAVE_TO_DATABASE`** — [documented](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setdisplayconfig) as *"can only be set with SDC_USE_SUPPLIED_DISPLAY_CONFIG"*, and that flag in turn *"cannot be set with any SDC_TOPOLOGY_XXX flag"*. Invalid here by construction.

- **`SDC_ALLOW_CHANGES`** — this one is not in the docs. It is rejected with *every* `SDC_TOPOLOGY_*` flag in practice, even though the same page states it *"is allowed with any other valid combination"*. The `CLONE` rows above isolate it. I could only find this by probing; the docs are wrong here.

I replaced both with **`SDC_PATH_PERSIST_IF_REQUIRED`**, which also addresses a second problem hiding behind the 87: `SDC_TOPOLOGY_EXTEND` *"requests the last extended configuration from the persistence database"* — it re-reads the database rather than enumerating hardware. A target detached through CCD (which `apply_layout_against_snapshot` does with `SDC_SAVE_TO_DATABASE`) is no longer part of that entry, so the extend has no reason to bring it back. `SDC_PATH_PERSIST_IF_REQUIRED` is documented to *"force path persistence on a target to satisfy the request if necessary"* and is legal alongside `SDC_TOPOLOGY_*`.

I also dropped the comment blaming *"some driver stacks ... during early-login / post-reboot states"* — the failure appears to be unconditional rather than a driver quirk -- though the observation behind that comment was right: Win+P does work, precisely because it does not go through these flags. A side effect worth noting: the `DisplaySwitch.exe /extend` fallback used to run on **every** call (because the call above it always failed). After this change it only runs when the extend actually fails, which is the intent, but it does mean the fallback now runs less often than before.

### Scope and honesty about what this does not fix

This makes the call legal — it does not on its own guarantee the display comes back, and I want to be upfront that I have not verified that it does. `SDC_TOPOLOGY_EXTEND` operates on the persistence database, and whether `SDC_PATH_PERSIST_IF_REQUIRED` is enough to pull a CCD-detached target back into it is something I could not test properly: my own machine has a single display, so my probes only prove the flags are accepted, not the outcome.

In my fork I ended up not relying on the extend at all for this — I keep the `DISPLAYCONFIG_PATH_INFO` of connected-but-inactive targets from a `QDC_ALL_PATHS` pass and activate the target explicitly (`SDC_USE_SUPPLIED_DISPLAY_CONFIG`, free source id, `SDC_VALIDATE` dry-run first), which is what Windows Display Settings effectively does when a user clicks Extend manually. That is a much larger change and touches your cache/topology design, so I am not proposing it here. Happy to open a separate PR or just describe the approach in an issue if it is of interest.

This PR is deliberately small: the flag combination is wrong regardless of anything else, and the probe script makes it verifiable in seconds.

Not compile-tested end to end (I do not have MSVC set up on this machine — my builds go through CI), though `SDC_PATH_PERSIST_IF_REQUIRED` exists in `windows` 0.60 (`SET_DISPLAY_CONFIG_FLAGS(2048u32)`) and the other two flags are still used by `apply_layout_against_snapshot`, so the imports stay live. Please run it through your build.

Thanks for Monarch — I use it every day, which is how I ended up this deep in it.
