### PR TITLE
fix(windows): recover previously-detached displays, unfreeze tray after sleep, fix topology-extend flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "monarch"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "monarch"
-version = "1.1.1"
+version = "1.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "monarch-desktop"
-version = "1.1.1"
+version = "1.5.1"
 dependencies = [
  "monarch",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ windows = { version = "0.60", features = [
   "Win32_Devices_Display",
   "Win32_Graphics_Gdi",
   "Win32_System_Com",
+  "Win32_System_LibraryLoader",
   "Win32_System_Threading",
   "Win32_UI_ColorSystem",
   "Win32_UI_Shell",

--- a/src-tauri/src/app/commands.rs
+++ b/src-tauri/src/app/commands.rs
@@ -14,6 +14,7 @@ use crate::app::events::{
 };
 use crate::app::state::{format_display_key, MonarchAppState};
 use crate::app::{shortcuts, startup};
+use crate::diagnostics;
 
 type CommandResult<T> = Result<T, String>;
 
@@ -129,6 +130,7 @@ pub async fn toggle_display<R: Runtime>(
     state: State<'_, MonarchAppState>,
     display_key: String,
 ) -> CommandResult<()> {
+    diagnostics::log(format!("ui_cmd:toggle_display:start:{display_key}"));
     let display_id =
         crate::app::state::parse_display_key(&display_key).map_err(|err| err.to_string())?;
 
@@ -178,6 +180,10 @@ pub async fn apply_layout<R: Runtime>(
     state: State<'_, MonarchAppState>,
     layout: LayoutDto,
 ) -> CommandResult<()> {
+    diagnostics::log(format!(
+        "ui_cmd:apply_layout:start:outputs={}",
+        layout.outputs.len()
+    ));
     let layout = dto_to_layout(layout)?;
     let timeout = {
         let mut guard = state
@@ -235,6 +241,7 @@ pub async fn apply_profile<R: Runtime>(
     state: State<'_, MonarchAppState>,
     name: String,
 ) -> CommandResult<()> {
+    diagnostics::log(format!("ui_cmd:apply_profile:start:{name}"));
     let pending_timeout = {
         let mut guard = state
             .0
@@ -288,6 +295,7 @@ pub async fn restore_last_layout<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, MonarchAppState>,
 ) -> CommandResult<()> {
+    diagnostics::log("ui_cmd:restore:start");
     {
         let mut guard = state
             .0
@@ -309,6 +317,7 @@ pub async fn confirm_current_layout<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, MonarchAppState>,
 ) -> CommandResult<()> {
+    diagnostics::log("ui_cmd:confirm");
     {
         let mut guard = state
             .0
@@ -332,6 +341,7 @@ pub async fn rollback_pending<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, MonarchAppState>,
 ) -> CommandResult<()> {
+    diagnostics::log("ui_cmd:rollback");
     {
         let mut guard = state
             .0

--- a/src-tauri/src/app/events.rs
+++ b/src-tauri/src/app/events.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use serde::Serialize;
@@ -6,9 +7,9 @@ use tauri::menu::{MenuBuilder, SubmenuBuilder};
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
 
-use crate::app::commands::{snapshot_from_manager, AppSnapshotDto};
 use crate::app::shortcuts;
 use crate::app::state::MonarchAppState;
+use crate::diagnostics;
 
 pub const EVENT_STATE_CHANGED: &str = "monarch://state-changed";
 pub const EVENT_CONFIRMATION: &str = "monarch://confirmation";
@@ -139,11 +140,10 @@ pub fn spawn_topology_state_watchdog<R: Runtime>(app: AppHandle<R>) {
         loop {
             std::thread::sleep(Duration::from_millis(1800));
 
-            let snapshot = match state_snapshot(&app) {
-                Ok(snapshot) => snapshot,
+            let signature = match topology_watch_signature(&app) {
+                Ok(signature) => signature,
                 Err(_) => continue,
             };
-            let signature = topology_signature(&snapshot);
 
             match &last_signature {
                 None => {
@@ -225,32 +225,43 @@ fn parse_color_state_signature(signature: &str) -> Option<HashMap<String, char>>
     Some(map)
 }
 
-fn topology_signature(snapshot: &AppSnapshotDto) -> String {
-    let mut displays = snapshot
-        .displays
+fn topology_watch_signature<R: Runtime>(app: &AppHandle<R>) -> Result<String, String> {
+    let state = app.state::<MonarchAppState>();
+    let guard = state
+        .0
+        .lock()
+        .map_err(|_| "state mutex poisoned".to_string())?;
+    let displays = guard
+        .manager
+        .list_displays()
+        .map_err(|err| err.to_string())?;
+
+    let mut entries = displays
         .iter()
         .map(|display| {
             (
-                display.id_key.as_str(),
+                display.id.adapter_luid,
+                display.id.target_id,
+                display.id.edid_hash,
                 display.is_active,
                 display.is_primary,
-                display.resolution.width,
-                display.resolution.height,
-                display.refresh_rate_mhz,
             )
         })
         .collect::<Vec<_>>();
-    displays.sort_by(|a, b| a.0.cmp(b.0));
+    entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)).then(a.2.cmp(&b.2)));
 
     let mut parts = Vec::with_capacity(displays.len());
-    for (id_key, is_active, is_primary, width, height, refresh_rate_mhz) in displays {
+    for (adapter_luid, target_id, edid_hash, is_active, is_primary) in entries {
         parts.push(format!(
-            "{id_key}:{}:{}:{width}x{height}:{refresh_rate_mhz}",
+            "{adapter_luid:016x}:{target_id}:{}:{}:{}",
+            edid_hash
+                .map(|value| format!("{value:016x}"))
+                .unwrap_or_else(|| "-".to_string()),
             if is_active { 1 } else { 0 },
             if is_primary { 1 } else { 0 }
         ));
     }
-    parts.join("|")
+    Ok(parts.join("|"))
 }
 
 pub fn build_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
@@ -268,14 +279,10 @@ pub fn build_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
             let app = app.clone();
             move |_tray, event| {
                 if let TrayIconEvent::DoubleClick { .. } = event {
-                    if let Some(window) = app.get_webview_window("main") {
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    }
+                    show_main_window(&app);
                 }
             }
-        })
-        ;
+        });
     if let Some(icon) = app.default_window_icon().cloned() {
         tray_builder = tray_builder.icon(icon);
     }
@@ -284,12 +291,50 @@ pub fn build_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
 }
 
 pub fn refresh_tray_menu<R: Runtime>(app: &AppHandle<R>) {
+    let _refresh_guard = match tray_menu_refresh_lock().try_lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            diagnostics::log("tray_refresh:skip_busy");
+            return;
+        }
+    };
     let Some(tray) = app.tray_by_id("monarch-tray") else {
         return;
     };
     if let Ok(menu) = build_tray_menu(app) {
         let _ = tray.set_menu(Some(menu));
     }
+}
+
+fn tray_action_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn tray_menu_refresh_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn spawn_serialized_action<R, F>(app: &AppHandle<R>, name: &'static str, action: F)
+where
+    R: Runtime,
+    F: FnOnce(AppHandle<R>) + Send + 'static,
+{
+    let app = app.clone();
+    std::thread::spawn(move || {
+        diagnostics::log(format!("tray_action:start:{name}"));
+        let guard = match tray_action_lock().lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                diagnostics::log(format!("tray_action:lock_poisoned:{name}"));
+                return;
+            }
+        };
+        action(app.clone());
+        drop(guard);
+        diagnostics::log(format!("tray_action:end:{name}"));
+    });
 }
 
 pub fn apply_profile_external_action_result<R: Runtime>(
@@ -301,12 +346,14 @@ pub fn apply_profile_external_action_result<R: Runtime>(
         .0
         .lock()
         .map_err(|_| "state mutex poisoned".to_string())?;
+    diagnostics::log(format!("apply_profile:start:{name}"));
     guard
         .manager
         .apply_profile(name)
         .map_err(|err| err.to_string())?;
     let pending_timeout = guard.manager.pending_confirmation_remaining();
-    let auto_confirmed = pending_timeout.is_some() && guard.manager.confirm_current_layout().is_ok();
+    let auto_confirmed =
+        pending_timeout.is_some() && guard.manager.confirm_current_layout().is_ok();
     drop(guard);
 
     let _ = shortcuts::sync_global_shortcuts(app);
@@ -322,14 +369,29 @@ pub fn apply_profile_external_action_result<R: Runtime>(
         );
         spawn_confirmation_watchdog(app.clone(), timeout);
     }
+    diagnostics::log(format!(
+        "apply_profile:done:{name}:auto_confirm={auto_confirmed}"
+    ));
     Ok(())
 }
 
 pub fn handle_profile_apply_external_action<R: Runtime>(app: &AppHandle<R>, name: &str) {
-    let _ = apply_profile_external_action_result(app, name);
+    let name = name.to_string();
+    spawn_serialized_action(app, "apply_profile", move |app| {
+        if let Err(err) = apply_profile_external_action_result(&app, &name) {
+            diagnostics::log(format!("apply_profile:error:{name}:{err}"));
+        }
+    });
 }
 
 pub fn handle_toggle_display_external_action<R: Runtime>(app: &AppHandle<R>, display_key: &str) {
+    let display_key = display_key.to_string();
+    spawn_serialized_action(app, "toggle_display", move |app| {
+        toggle_display_external_action_inner(&app, &display_key);
+    });
+}
+
+fn toggle_display_external_action_inner<R: Runtime>(app: &AppHandle<R>, display_key: &str) {
     let state = app.state::<MonarchAppState>();
     let lock = state.0.lock();
     if let Ok(mut guard) = lock {
@@ -354,8 +416,16 @@ pub fn handle_toggle_display_external_action<R: Runtime>(app: &AppHandle<R>, dis
                     );
                     spawn_confirmation_watchdog(app.clone(), timeout);
                 }
+            } else {
+                diagnostics::log(format!(
+                    "toggle_display:error:manager_toggle_failed:{display_key}"
+                ));
             }
+        } else {
+            diagnostics::log(format!("toggle_display:error:invalid_key:{display_key}"));
         }
+    } else {
+        diagnostics::log("toggle_display:error:state_lock_failed");
     }
 }
 
@@ -368,8 +438,49 @@ pub fn spawn_deferred_tray_refresh<R: Runtime>(app: AppHandle<R>, delay: Duratio
     });
 }
 
+#[derive(Clone)]
+struct TrayMenuDisplay {
+    id_key: String,
+    friendly_name: String,
+    is_active: bool,
+}
+
+#[derive(Clone)]
+struct TrayMenuSnapshot {
+    profiles: Vec<String>,
+    displays: Vec<TrayMenuDisplay>,
+}
+
+fn tray_menu_snapshot<R: Runtime>(app: &AppHandle<R>) -> Result<TrayMenuSnapshot, String> {
+    let state = app.state::<MonarchAppState>();
+    let guard = state
+        .0
+        .lock()
+        .map_err(|_| "state mutex poisoned".to_string())?;
+
+    let profiles = guard
+        .manager
+        .list_profiles()
+        .into_iter()
+        .map(|profile| profile.name)
+        .collect::<Vec<_>>();
+    let displays = guard
+        .manager
+        .list_displays()
+        .map_err(|err| err.to_string())?
+        .into_iter()
+        .map(|display| TrayMenuDisplay {
+            id_key: crate::app::state::format_display_key(&display.id),
+            friendly_name: display.friendly_name,
+            is_active: display.is_active,
+        })
+        .collect::<Vec<_>>();
+
+    Ok(TrayMenuSnapshot { profiles, displays })
+}
+
 fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<tauri::menu::Menu<R>> {
-    let snapshot = state_snapshot(app).ok();
+    let snapshot = tray_menu_snapshot(app).ok();
 
     let mut profiles_menu = SubmenuBuilder::new(app, "Profiles");
     if let Some(snapshot) = &snapshot {
@@ -377,8 +488,7 @@ fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<tauri::menu:
             profiles_menu = profiles_menu.text("profiles.none", "(No Profiles)");
         } else {
             for profile in &snapshot.profiles {
-                profiles_menu =
-                    profiles_menu.text(format!("profile::{}", profile.name), profile.name.clone());
+                profiles_menu = profiles_menu.text(format!("profile::{profile}"), profile.clone());
             }
         }
     }
@@ -408,22 +518,18 @@ fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<tauri::menu:
     Ok(menu)
 }
 
-fn state_snapshot<R: Runtime>(app: &AppHandle<R>) -> Result<AppSnapshotDto, String> {
-    let state = app.state::<MonarchAppState>();
-    let guard = state
-        .0
-        .lock()
-        .map_err(|_| "state mutex poisoned".to_string())?;
-    snapshot_from_manager(&guard.manager).map_err(|err| err.to_string())
+pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
 }
 
 fn handle_tray_menu_event<R: Runtime>(app: &AppHandle<R>, id: &str) {
     match id {
         "open_main" => {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            show_main_window(app);
         }
         "quit_app" => {
             app.exit(0);
@@ -446,13 +552,19 @@ fn handle_tray_menu_event<R: Runtime>(app: &AppHandle<R>, id: &str) {
 }
 
 fn handle_restore_last_layout<R: Runtime>(app: &AppHandle<R>) {
-    let state = app.state::<MonarchAppState>();
-    let lock = state.0.lock();
-    if let Ok(mut guard) = lock {
-        if guard.manager.restore_last_layout().is_ok() {
-            drop(guard);
-            refresh_tray_menu(app);
-            emit_state_changed(app);
+    spawn_serialized_action(app, "restore_last_layout", move |app| {
+        let state = app.state::<MonarchAppState>();
+        let lock = state.0.lock();
+        if let Ok(mut guard) = lock {
+            if guard.manager.restore_last_layout().is_ok() {
+                drop(guard);
+                refresh_tray_menu(&app);
+                emit_state_changed(&app);
+            } else {
+                diagnostics::log("restore_last_layout:error:manager_restore_failed");
+            }
+        } else {
+            diagnostics::log("restore_last_layout:error:state_lock_failed");
         }
-    }
+    });
 }

--- a/src-tauri/src/app/events.rs
+++ b/src-tauri/src/app/events.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
@@ -50,6 +51,7 @@ pub fn spawn_confirmation_watchdog<R: Runtime>(app: AppHandle<R>, timeout: Durat
         match guard.manager.rollback_if_confirmation_expired() {
             Ok(true) => {
                 drop(guard);
+                diagnostics::log("confirm_watchdog:rolled_back:timeout");
                 refresh_tray_menu(&app);
                 emit_state_changed(&app);
                 emit_confirmation(
@@ -60,8 +62,9 @@ pub fn spawn_confirmation_watchdog<R: Runtime>(app: AppHandle<R>, timeout: Durat
                 );
             }
             Ok(false) => {}
-            Err(_) => {
+            Err(err) => {
                 drop(guard);
+                diagnostics::log(format!("confirm_watchdog:rollback_error:{err}"));
                 emit_confirmation(
                     &app,
                     ConfirmationEvent::Reverted {
@@ -294,16 +297,53 @@ pub fn refresh_tray_menu<R: Runtime>(app: &AppHandle<R>) {
     let _refresh_guard = match tray_menu_refresh_lock().try_lock() {
         Ok(guard) => guard,
         Err(_) => {
+            // Another refresh is in flight. Don't drop this one silently: schedule a single
+            // deferred retry so the menu still converges on the latest state.
             diagnostics::log("tray_refresh:skip_busy");
+            schedule_tray_refresh_retry(app);
             return;
         }
     };
+    tray_refresh_retry_delay_ms().store(TRAY_REFRESH_RETRY_BASE_MS, Ordering::SeqCst);
     let Some(tray) = app.tray_by_id("monarch-tray") else {
         return;
     };
     if let Ok(menu) = build_tray_menu(app) {
         let _ = tray.set_menu(Some(menu));
     }
+}
+
+const TRAY_REFRESH_RETRY_BASE_MS: u64 = 300;
+const TRAY_REFRESH_RETRY_MAX_MS: u64 = 5000;
+
+fn tray_refresh_retry_pending() -> &'static AtomicBool {
+    static PENDING: OnceLock<AtomicBool> = OnceLock::new();
+    PENDING.get_or_init(|| AtomicBool::new(false))
+}
+
+fn tray_refresh_retry_delay_ms() -> &'static AtomicU64 {
+    static DELAY: OnceLock<AtomicU64> = OnceLock::new();
+    DELAY.get_or_init(|| AtomicU64::new(TRAY_REFRESH_RETRY_BASE_MS))
+}
+
+fn schedule_tray_refresh_retry<R: Runtime>(app: &AppHandle<R>) {
+    if tray_refresh_retry_pending()
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    // Exponential backoff (capped) so a long-blocked holder does not produce a thread+log
+    // storm every 300ms; the delay resets once a refresh actually gets through.
+    let delay_ms = tray_refresh_retry_delay_ms().load(Ordering::SeqCst);
+    let next_delay_ms = (delay_ms * 2).min(TRAY_REFRESH_RETRY_MAX_MS);
+    tray_refresh_retry_delay_ms().store(next_delay_ms, Ordering::SeqCst);
+    let app = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(delay_ms));
+        tray_refresh_retry_pending().store(false, Ordering::SeqCst);
+        refresh_tray_menu(&app);
+    });
 }
 
 fn tray_action_lock() -> &'static Mutex<()> {
@@ -567,4 +607,212 @@ fn handle_restore_last_layout<R: Runtime>(app: &AppHandle<R>) {
             diagnostics::log("restore_last_layout:error:state_lock_failed");
         }
     });
+}
+
+/// Subscribe to system power-resume and display-change broadcasts so the backend cache is
+/// invalidated and the tray/UI refreshed right after a sleep-wake cycle, instead of waiting for
+/// the polling watchdogs to notice (or never noticing a stale cache at all).
+pub fn spawn_system_event_listener<R: Runtime>(app: AppHandle<R>) {
+    #[cfg(target_os = "windows")]
+    system_events::spawn(app);
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = app;
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod system_events {
+    use std::sync::mpsc::{self, RecvTimeoutError, Sender};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Duration;
+
+    use tauri::{AppHandle, Manager, Runtime};
+    use windows::core::w;
+    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DispatchMessageW, GetMessageW, RegisterClassW,
+        TranslateMessage, MSG, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND, WM_DISPLAYCHANGE,
+        WM_POWERBROADCAST, WNDCLASSW,
+    };
+
+    use crate::app::state::MonarchAppState;
+    use crate::diagnostics;
+
+    // Let the display stack settle after resume before rebuilding state.
+    const RESUME_DEBOUNCE: Duration = Duration::from_millis(2000);
+    const DISPLAY_CHANGE_DEBOUNCE: Duration = Duration::from_millis(500);
+
+    #[derive(Clone, Copy, PartialEq)]
+    enum SystemEvent {
+        Resume,
+        DisplayChange,
+    }
+
+    fn event_sender_slot() -> &'static OnceLock<Mutex<Sender<SystemEvent>>> {
+        static SENDER: OnceLock<Mutex<Sender<SystemEvent>>> = OnceLock::new();
+        &SENDER
+    }
+
+    pub fn spawn<R: Runtime>(app: AppHandle<R>) {
+        let (sender, receiver) = mpsc::channel::<SystemEvent>();
+        if event_sender_slot().set(Mutex::new(sender)).is_err() {
+            diagnostics::log("system_events:error:already_spawned");
+            return;
+        }
+
+        std::thread::spawn(run_message_pump);
+        std::thread::spawn(move || consume_events(app, receiver));
+    }
+
+    fn notify(event: SystemEvent) {
+        let Some(sender) = event_sender_slot().get() else {
+            return;
+        };
+        let Ok(sender) = sender.lock() else {
+            return;
+        };
+        let _ = sender.send(event);
+    }
+
+    /// Debounce loop: absorb bursts of resume/display-change notifications, then run one refresh
+    /// per settled burst. Never touches any lock on the message-pump thread.
+    fn consume_events<R: Runtime>(app: AppHandle<R>, receiver: mpsc::Receiver<SystemEvent>) {
+        loop {
+            let first = match receiver.recv() {
+                Ok(event) => event,
+                Err(_) => return,
+            };
+            let mut saw_resume = first == SystemEvent::Resume;
+
+            loop {
+                let settle = if saw_resume {
+                    RESUME_DEBOUNCE
+                } else {
+                    DISPLAY_CHANGE_DEBOUNCE
+                };
+                match receiver.recv_timeout(settle) {
+                    Ok(SystemEvent::Resume) => saw_resume = true,
+                    Ok(SystemEvent::DisplayChange) => {}
+                    Err(RecvTimeoutError::Timeout) => break,
+                    Err(RecvTimeoutError::Disconnected) => return,
+                }
+            }
+
+            diagnostics::log(format!("system_event:settled:resume={saw_resume}"));
+            handle_settled_event(&app, saw_resume);
+        }
+    }
+
+    fn handle_settled_event<R: Runtime>(app: &AppHandle<R>, resume: bool) {
+        let action_name = if resume {
+            "system_resume_refresh"
+        } else {
+            "display_change_refresh"
+        };
+        super::spawn_serialized_action(app, action_name, move |app| {
+            if resume {
+                // Only a resume invalidates the backend cache: adapter LUIDs may have changed
+                // and transient EDID failures may have polluted it. Plain WM_DISPLAYCHANGE must
+                // NOT invalidate, or the detached-display cache would be lost on every apply.
+                let state = app.state::<MonarchAppState>();
+                match state.0.lock() {
+                    Ok(guard) => {
+                        if let Err(err) = guard.manager.invalidate_backend_cache() {
+                            diagnostics::log(format!("system_resume:invalidate_cache_error:{err}"));
+                        }
+                    }
+                    Err(_) => {
+                        diagnostics::log("system_resume:error:state_lock_failed");
+                        return;
+                    }
+                };
+            }
+            let _ = crate::app::shortcuts::sync_global_shortcuts(&app);
+            super::refresh_tray_menu(&app);
+            super::emit_state_changed(&app);
+        });
+    }
+
+    /// NOTE: deliberately NOT a message-only window (HWND_MESSAGE parent): message-only windows
+    /// never receive broadcast messages such as WM_POWERBROADCAST/WM_DISPLAYCHANGE. A hidden
+    /// top-level window does.
+    fn run_message_pump() {
+        unsafe {
+            let instance = match GetModuleHandleW(None) {
+                Ok(instance) => instance,
+                Err(err) => {
+                    diagnostics::log(format!("system_events:error:get_module_handle:{err}"));
+                    return;
+                }
+            };
+
+            let class_name = w!("MonarchSystemEventWindow");
+            let window_class = WNDCLASSW {
+                lpfnWndProc: Some(system_event_wndproc),
+                hInstance: instance.into(),
+                lpszClassName: class_name,
+                ..Default::default()
+            };
+            if RegisterClassW(&window_class) == 0 {
+                diagnostics::log("system_events:error:register_class_failed");
+                return;
+            }
+
+            let window = match CreateWindowExW(
+                Default::default(),
+                class_name,
+                w!("Monarch System Events"),
+                Default::default(),
+                0,
+                0,
+                0,
+                0,
+                None,
+                None,
+                Some(instance.into()),
+                None,
+            ) {
+                Ok(window) => window,
+                Err(err) => {
+                    diagnostics::log(format!("system_events:error:create_window:{err}"));
+                    return;
+                }
+            };
+            let _ = window;
+
+            diagnostics::log("system_events:listener_started");
+            let mut message = MSG::default();
+            while GetMessageW(&mut message, None, 0, 0).0 > 0 {
+                let _ = TranslateMessage(&message);
+                DispatchMessageW(&message);
+            }
+            // Covers both WM_QUIT (0) and the -1 error return: if the pump dies, resume
+            // protection is off — make that visible in the diagnostics log.
+            diagnostics::log("system_events:error:message_pump_exited");
+        }
+    }
+
+    unsafe extern "system" fn system_event_wndproc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        match msg {
+            WM_POWERBROADCAST => {
+                let power_event = wparam.0 as u32;
+                if power_event == PBT_APMRESUMEAUTOMATIC || power_event == PBT_APMRESUMESUSPEND {
+                    notify(SystemEvent::Resume);
+                }
+                LRESULT(1)
+            }
+            WM_DISPLAYCHANGE => {
+                notify(SystemEvent::DisplayChange);
+                LRESULT(0)
+            }
+            _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+        }
+    }
 }

--- a/src-tauri/src/app/ipc.rs
+++ b/src-tauri/src/app/ipc.rs
@@ -14,6 +14,7 @@ const IPC_IO_TIMEOUT: Duration = Duration::from_secs(3);
 #[serde(tag = "type", rename_all = "snake_case")]
 enum IpcRequest {
     ApplyProfile { name: String },
+    ShowMainWindow,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -23,6 +24,16 @@ struct IpcResponse {
 }
 
 pub fn send_apply_profile_request(profile_name: &str) -> Result<(), String> {
+    send_request(IpcRequest::ApplyProfile {
+        name: profile_name.to_string(),
+    })
+}
+
+pub fn send_show_main_window_request() -> Result<(), String> {
+    send_request(IpcRequest::ShowMainWindow)
+}
+
+fn send_request(request: IpcRequest) -> Result<(), String> {
     let mut stream = TcpStream::connect(IPC_BIND_ADDR)
         .map_err(|err| format!("failed to connect to running Monarch instance: {err}"))?;
     stream
@@ -32,11 +43,8 @@ pub fn send_apply_profile_request(profile_name: &str) -> Result<(), String> {
         .set_write_timeout(Some(IPC_IO_TIMEOUT))
         .map_err(|err| format!("failed to set IPC write timeout: {err}"))?;
 
-    let request = IpcRequest::ApplyProfile {
-        name: profile_name.to_string(),
-    };
-    let mut request_bytes =
-        serde_json::to_vec(&request).map_err(|err| format!("failed to encode IPC request: {err}"))?;
+    let mut request_bytes = serde_json::to_vec(&request)
+        .map_err(|err| format!("failed to encode IPC request: {err}"))?;
     request_bytes.push(b'\n');
     stream
         .write_all(&request_bytes)
@@ -89,7 +97,10 @@ pub fn spawn_listener<R: Runtime>(app: AppHandle<R>) {
     });
 }
 
-fn handle_client_stream<R: Runtime>(app: &AppHandle<R>, mut stream: TcpStream) -> Result<(), String> {
+fn handle_client_stream<R: Runtime>(
+    app: &AppHandle<R>,
+    mut stream: TcpStream,
+) -> Result<(), String> {
     stream
         .set_read_timeout(Some(IPC_IO_TIMEOUT))
         .map_err(|err| format!("failed to set client read timeout: {err}"))?;
@@ -111,7 +122,13 @@ fn handle_client_stream<R: Runtime>(app: &AppHandle<R>, mut stream: TcpStream) -
         .map_err(|err| format!("invalid IPC request payload: {err}"))?;
 
     let result = match request {
-        IpcRequest::ApplyProfile { name } => events::apply_profile_external_action_result(app, &name),
+        IpcRequest::ApplyProfile { name } => {
+            events::apply_profile_external_action_result(app, &name)
+        }
+        IpcRequest::ShowMainWindow => {
+            events::show_main_window(app);
+            Ok(())
+        }
     };
 
     let response = match result {

--- a/src-tauri/src/app/ipc.rs
+++ b/src-tauri/src/app/ipc.rs
@@ -1,5 +1,6 @@
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -9,6 +10,9 @@ use crate::app::events;
 
 const IPC_BIND_ADDR: &str = "127.0.0.1:42197";
 const IPC_IO_TIMEOUT: Duration = Duration::from_secs(3);
+const MAX_CONCURRENT_IPC_HANDLERS: usize = 8;
+
+static ACTIVE_IPC_HANDLERS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -85,8 +89,25 @@ pub fn spawn_listener<R: Runtime>(app: AppHandle<R>) {
         for stream in listener.incoming() {
             match stream {
                 Ok(stream) => {
-                    if let Err(err) = handle_client_stream(&app, stream) {
-                        eprintln!("Monarch IPC request failed: {err}");
+                    // One thread per connection (bounded): a ShowMainWindow from a relaunch must
+                    // be served even while an earlier ApplyProfile is still blocked on the state
+                    // mutex, but a burst of sockets must not spawn unbounded threads. Above the
+                    // cap, fall back to handling the connection inline on the accept loop.
+                    if ACTIVE_IPC_HANDLERS.fetch_add(1, Ordering::SeqCst)
+                        < MAX_CONCURRENT_IPC_HANDLERS
+                    {
+                        let app = app.clone();
+                        std::thread::spawn(move || {
+                            if let Err(err) = handle_client_stream(&app, stream) {
+                                eprintln!("Monarch IPC request failed: {err}");
+                            }
+                            ACTIVE_IPC_HANDLERS.fetch_sub(1, Ordering::SeqCst);
+                        });
+                    } else {
+                        ACTIVE_IPC_HANDLERS.fetch_sub(1, Ordering::SeqCst);
+                        if let Err(err) = handle_client_stream(&app, stream) {
+                            eprintln!("Monarch IPC request failed: {err}");
+                        }
                     }
                 }
                 Err(err) => {

--- a/src-tauri/src/app/mod.rs
+++ b/src-tauri/src/app/mod.rs
@@ -3,8 +3,8 @@ pub mod events;
 pub mod ipc;
 pub mod shortcuts;
 pub mod single_instance;
-pub mod state;
 pub mod startup;
+pub mod state;
 
 pub fn run() {
     state::run_app();

--- a/src-tauri/src/app/shortcuts.rs
+++ b/src-tauri/src/app/shortcuts.rs
@@ -35,22 +35,24 @@ pub fn sync_global_shortcuts<R: Runtime>(app: &AppHandle<R>) -> Result<(), Strin
         let action = binding.action.clone();
         let label = binding.label.clone();
 
-        if let Err(err) = manager.on_shortcut(shortcut_string.as_str(), move |app_handle, _, event| {
-            if event.state != ShortcutState::Pressed {
-                return;
-            }
+        if let Err(err) =
+            manager.on_shortcut(shortcut_string.as_str(), move |app_handle, _, event| {
+                if event.state != ShortcutState::Pressed {
+                    return;
+                }
 
-            let app_handle = app_handle.clone();
-            let action = action.clone();
-            std::thread::spawn(move || match action {
-                ShortcutAction::ApplyProfile(name) => {
-                    handle_profile_apply_external_action(&app_handle, &name)
-                }
-                ShortcutAction::ToggleDisplay(display_key) => {
-                    handle_toggle_display_external_action(&app_handle, &display_key)
-                }
-            });
-        }) {
+                let app_handle = app_handle.clone();
+                let action = action.clone();
+                std::thread::spawn(move || match action {
+                    ShortcutAction::ApplyProfile(name) => {
+                        handle_profile_apply_external_action(&app_handle, &name)
+                    }
+                    ShortcutAction::ToggleDisplay(display_key) => {
+                        handle_toggle_display_external_action(&app_handle, &display_key)
+                    }
+                });
+            })
+        {
             let _ = manager.unregister_all();
             return Err(format!(
                 "failed to register global shortcut '{shortcut_string}' for {label}: {err}"
@@ -91,17 +93,18 @@ fn collect_bindings<R: Runtime>(app: &AppHandle<R>) -> Result<Vec<ShortcutBindin
             Some(trimmed.to_string())
         }
     });
-    let display_toggle_shortcut_base = settings
-        .display_toggle_shortcut_base
-        .clone()
-        .and_then(|value| {
-            let trimmed = value.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        });
+    let display_toggle_shortcut_base =
+        settings
+            .display_toggle_shortcut_base
+            .clone()
+            .and_then(|value| {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            });
     let profile_shortcuts = settings.profile_shortcuts.clone();
     let display_toggle_shortcuts = settings.display_toggle_shortcuts.clone();
 

--- a/src-tauri/src/app/shortcuts.rs
+++ b/src-tauri/src/app/shortcuts.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeSet, HashMap};
+use std::sync::{Mutex, OnceLock};
 
 use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
@@ -21,7 +22,18 @@ struct ShortcutBinding {
     label: String,
 }
 
+fn sync_shortcuts_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 pub fn sync_global_shortcuts<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
+    // Serialize concurrent syncs: two racing callers can otherwise interleave
+    // unregister_all/on_shortcut and leave zero shortcuts registered until the next sync.
+    // Blocking lock (not try_lock) so the last caller always converges on the latest state.
+    let _sync_guard = sync_shortcuts_lock()
+        .lock()
+        .map_err(|_| "shortcut sync lock poisoned".to_string())?;
     let bindings = collect_bindings(app)?;
     validate_unique_shortcuts(&bindings)?;
 

--- a/src-tauri/src/app/state.rs
+++ b/src-tauri/src/app/state.rs
@@ -23,7 +23,9 @@ pub fn run_app() {
                     eprintln!("Monarch is already running and IPC profile apply failed: {err}");
                 }
             } else {
-                eprintln!("Monarch is already running.");
+                if let Err(err) = crate::app::ipc::send_show_main_window_request() {
+                    eprintln!("Monarch is already running and IPC show-main failed: {err}");
+                }
             }
             return;
         }

--- a/src-tauri/src/app/state.rs
+++ b/src-tauri/src/app/state.rs
@@ -40,29 +40,13 @@ pub fn run_app() {
         .setup(|app| {
             let backend = SystemDisplayBackend::new().map_err(|err| err.to_string())?;
             let store = FileConfigStore::default();
-            let mut manager =
+            let manager =
                 MonarchDisplayManager::new(backend, store).map_err(|err| err.to_string())?;
             let should_start_hidden = startup::should_start_hidden();
+            // CLI argument wins over the saved startup profile setting.
             let requested_profile_name = startup::requested_profile_name();
-            let startup_profile_name = requested_profile_name
-                .or_else(|| manager.settings().startup_profile_name.clone());
-
-            if let Some(profile_name) = startup_profile_name {
-                match manager.apply_profile(&profile_name) {
-                    Ok(()) => {
-                        if manager.has_pending_confirmation() {
-                            if let Err(err) = manager.confirm_current_layout() {
-                                eprintln!(
-                                    "Monarch launch profile confirm failed for '{profile_name}': {err}"
-                                );
-                            }
-                        }
-                    }
-                    Err(err) => {
-                        eprintln!("Monarch launch profile apply failed for '{profile_name}': {err}");
-                    }
-                }
-            }
+            let startup_profile_name =
+                requested_profile_name.or_else(|| manager.settings().startup_profile_name.clone());
 
             let startup_enabled = manager.settings().start_with_windows;
             let state = MonarchAppState(Mutex::new(MonarchRuntimeState { manager }));
@@ -79,7 +63,16 @@ pub fn run_app() {
             events::refresh_tray_menu(&app.handle());
             events::spawn_color_state_watchdog(app.handle().clone());
             events::spawn_topology_state_watchdog(app.handle().clone());
+            events::spawn_system_event_listener(app.handle().clone());
             crate::app::ipc::spawn_listener(app.handle().clone());
+
+            // Apply the startup profile on a worker thread AFTER tray/IPC exist: a wedged apply
+            // at login must never leave an invisible, unkillable app. The external-action helper
+            // keeps the auto-confirm semantics the old synchronous path had.
+            if let Some(profile_name) = startup_profile_name {
+                crate::diagnostics::log(format!("startup_profile:queued:{profile_name}"));
+                events::handle_profile_apply_external_action(&app.handle(), &profile_name);
+            }
 
             if let Some(window) = app.get_webview_window("main") {
                 if should_start_hidden {

--- a/src-tauri/src/backend/mod.rs
+++ b/src-tauri/src/backend/mod.rs
@@ -66,6 +66,22 @@ impl DisplayBackend for SystemDisplayBackend {
             Self::Mock(backend) => backend.reapply_color_calibration(),
         }
     }
+
+    fn invalidate_cache(&self) -> Result<(), monarch::ManagerError> {
+        match self {
+            #[cfg(target_os = "windows")]
+            Self::Windows(backend) => backend.invalidate_cache(),
+            Self::Mock(backend) => DisplayBackend::invalidate_cache(backend),
+        }
+    }
+
+    fn prepare_attach_targets(&self, desired: &Layout) -> Result<(), monarch::ManagerError> {
+        match self {
+            #[cfg(target_os = "windows")]
+            Self::Windows(backend) => backend.prepare_attach_targets(desired),
+            Self::Mock(backend) => DisplayBackend::prepare_attach_targets(backend, desired),
+        }
+    }
 }
 
 fn build_mock_backend() -> Result<MockBackend, monarch::ManagerError> {

--- a/src-tauri/src/backend/windows/apply.rs
+++ b/src-tauri/src/backend/windows/apply.rs
@@ -14,10 +14,10 @@ use windows::Win32::Devices::Display::{
     DisplayConfigGetDeviceInfo, SetDisplayConfig,
     DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO, DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME,
     DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME, DISPLAYCONFIG_DEVICE_INFO_HEADER,
-    DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO, DISPLAYCONFIG_MODE_INFO, DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE,
-    DISPLAYCONFIG_PATH_INFO, DISPLAYCONFIG_SOURCE_DEVICE_NAME, DISPLAYCONFIG_TARGET_DEVICE_NAME,
-    SDC_ALLOW_CHANGES, SDC_APPLY, SDC_NO_OPTIMIZATION, SDC_SAVE_TO_DATABASE, SDC_TOPOLOGY_EXTEND,
-    SDC_USE_SUPPLIED_DISPLAY_CONFIG,
+    DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO, DISPLAYCONFIG_MODE_INFO,
+    DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE, DISPLAYCONFIG_PATH_INFO, DISPLAYCONFIG_SOURCE_DEVICE_NAME,
+    DISPLAYCONFIG_TARGET_DEVICE_NAME, SDC_ALLOW_CHANGES, SDC_APPLY, SDC_NO_OPTIMIZATION,
+    SDC_SAVE_TO_DATABASE, SDC_TOPOLOGY_EXTEND, SDC_USE_SUPPLIED_DISPLAY_CONFIG,
 };
 use windows::Win32::Graphics::Gdi::{CreateDCW, DeleteDC};
 use windows::Win32::System::Com::{
@@ -28,9 +28,7 @@ use windows::Win32::UI::ColorSystem::{
     GetDeviceGammaRamp, SetDeviceGammaRamp, WcsGetCalibrationManagementState,
     WcsSetCalibrationManagementState,
 };
-use windows::Win32::UI::Shell::{
-    DesktopWallpaper, IDesktopWallpaper, DESKTOP_WALLPAPER_POSITION,
-};
+use windows::Win32::UI::Shell::{DesktopWallpaper, IDesktopWallpaper, DESKTOP_WALLPAPER_POSITION};
 
 use super::win32_types::{luid_to_u64, TopologySnapshot};
 
@@ -670,7 +668,10 @@ fn set_wallpaper_for_monitor(
     let wallpaper_wide = to_wide_null(wallpaper_path);
     unsafe {
         desktop_wallpaper
-            .SetWallpaper(PCWSTR(monitor_wide.as_ptr()), PCWSTR(wallpaper_wide.as_ptr()))
+            .SetWallpaper(
+                PCWSTR(monitor_wide.as_ptr()),
+                PCWSTR(wallpaper_wide.as_ptr()),
+            )
             .is_ok()
     }
 }

--- a/src-tauri/src/backend/windows/apply.rs
+++ b/src-tauri/src/backend/windows/apply.rs
@@ -5,8 +5,10 @@ use std::ffi::OsStr;
 use std::mem::size_of;
 use std::os::windows::ffi::OsStrExt;
 use std::os::windows::process::CommandExt;
-use std::process::Command;
+use std::process::{Child, Command, ExitStatus};
+use std::time::{Duration, Instant};
 
+use crate::diagnostics;
 use monarch::{Layout, ManagerError};
 use windows::core::BOOL;
 use windows::core::{w, PCWSTR};
@@ -17,7 +19,8 @@ use windows::Win32::Devices::Display::{
     DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO, DISPLAYCONFIG_MODE_INFO,
     DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE, DISPLAYCONFIG_PATH_INFO, DISPLAYCONFIG_SOURCE_DEVICE_NAME,
     DISPLAYCONFIG_TARGET_DEVICE_NAME, SDC_ALLOW_CHANGES, SDC_APPLY, SDC_NO_OPTIMIZATION,
-    SDC_SAVE_TO_DATABASE, SDC_TOPOLOGY_EXTEND, SDC_USE_SUPPLIED_DISPLAY_CONFIG,
+    SDC_PATH_PERSIST_IF_REQUIRED, SDC_SAVE_TO_DATABASE, SDC_TOPOLOGY_EXTEND,
+    SDC_USE_SUPPLIED_DISPLAY_CONFIG, SDC_VALIDATE,
 };
 use windows::Win32::Graphics::Gdi::{CreateDCW, DeleteDC};
 use windows::Win32::System::Com::{
@@ -30,9 +33,11 @@ use windows::Win32::UI::ColorSystem::{
 };
 use windows::Win32::UI::Shell::{DesktopWallpaper, IDesktopWallpaper, DESKTOP_WALLPAPER_POSITION};
 
-use super::win32_types::{luid_to_u64, TopologySnapshot};
+use super::win32_types::{luid_to_u64, AttachablePath, TopologySnapshot};
 
 const DISPLAYCONFIG_PATH_ACTIVE_FLAG: u32 = 0x0000_0001;
+/// `DISPLAYCONFIG_PATH_MODE_IDX_INVALID`: "no mode supplied, let Windows pick one".
+const DISPLAYCONFIG_PATH_MODE_IDX_INVALID: u32 = 0xffff_ffff;
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 const GAMMA_RAMP_WORDS: usize = 3 * 256;
 pub(super) type GammaRampKey = (u64, u32);
@@ -81,6 +86,7 @@ pub fn apply_layout_against_snapshot(
             exact_flags,
         );
         if status != 0 {
+            diagnostics::log(format!("apply:sdc_failed:{status}:exact_flags"));
             status = SetDisplayConfig(
                 Some(next_paths.as_slice()),
                 Some(next_modes.as_slice()),
@@ -92,6 +98,7 @@ pub fn apply_layout_against_snapshot(
         }
 
         if status != 0 {
+            diagnostics::log(format!("apply:sdc_failed:{status}:allow_changes"));
             return Err(ManagerError::Backend(format!(
                 "SetDisplayConfig failed: {}",
                 status
@@ -107,34 +114,159 @@ pub fn apply_layout_against_snapshot(
     Ok(next_snapshot)
 }
 
-pub(super) fn force_topology_extend() -> Result<(), ManagerError> {
-    let set_display_status = unsafe {
+/// Build the path array that activates `candidates` on top of the currently active paths: the
+/// active paths keep their mode indices (so the other displays hold their exact geometry) and
+/// each candidate is appended with the ACTIVE flag and no mode indices, letting Windows compute
+/// its mode. This is what Windows Display settings does, and it is the cure for the case
+/// SDC_TOPOLOGY_EXTEND cannot fix: the extend replays the last extended configuration from the
+/// persistence database, which a Monarch detach (saved with SDC_SAVE_TO_DATABASE) already
+/// stripped this display from.
+///
+/// The array is the COMPLETE topology (SDC_USE_SUPPLIED_DISPLAY_CONFIG): any path left out is
+/// deactivated. Every candidate must therefore go in one array — attaching them one call at a
+/// time would detach whatever the previous call attached.
+///
+/// What SDC_VALIDATE probes actually established (on a single-display machine):
+///   active paths + supplied mode array, one path with invalid mode indices -> accepted
+///   every path with invalid mode indices + NULL mode array                 -> 87, always
+/// so the mode-less shape is a parameter-level rejection and is not attempted.
+///
+/// Appending the path of a currently INACTIVE target — the exact operation below — could not be
+/// probed there (that machine has no connected-but-inactive target), but a field log since
+/// confirmed it on real hardware: a TV detached before an app restart, on a 3-display desktop,
+/// came back on the first poll.
+///   recover:explicit_attach:'Smart TV Pro' (target_id=4352, ...):source=2:validate=0
+///   recover:explicit_attach:batch=1:apply=0
+///   recover:settle_poll:attach:1:missing=0
+/// The mandatory SDC_VALIDATE dry-run before every apply still gates each attempt at runtime:
+/// one machine agreeing is not every driver agreeing.
+///
+/// Returns an empty vec when there are no active paths to build on.
+pub(super) fn build_attach_paths(
+    candidates: &[&AttachablePath],
+    active_snapshot: &TopologySnapshot,
+) -> Vec<DISPLAYCONFIG_PATH_INFO> {
+    let mut paths: Vec<DISPLAYCONFIG_PATH_INFO> = active_snapshot
+        .raw
+        .paths
+        .iter()
+        .filter(|path| path.flags & DISPLAYCONFIG_PATH_ACTIVE_FLAG != 0)
+        .copied()
+        .collect();
+    if paths.is_empty() {
+        return Vec::new();
+    }
+
+    for candidate in candidates {
+        let mut next = candidate.path;
+        next.flags |= DISPLAYCONFIG_PATH_ACTIVE_FLAG;
+        unsafe {
+            next.sourceInfo.Anonymous.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+            next.targetInfo.Anonymous.modeInfoIdx = DISPLAYCONFIG_PATH_MODE_IDX_INVALID;
+        }
+        paths.push(next);
+    }
+    paths
+}
+
+/// SDC_ALLOW_CHANGES is legal here (and needed so Windows may compute the new mode): it is only
+/// rejected alongside SDC_TOPOLOGY_*.
+fn attach_flags() -> windows::Win32::Devices::Display::SET_DISPLAY_CONFIG_FLAGS {
+    SDC_USE_SUPPLIED_DISPLAY_CONFIG | SDC_ALLOW_CHANGES
+}
+
+/// Dry-run: SDC_VALIDATE changes nothing, so it is free to call and mandatory before applying —
+/// this runs on desktops with no internal panel, where a bad apply leaves no rescue screen.
+/// Returns the raw SetDisplayConfig status (0 = the configuration is accepted).
+pub(super) fn validate_attach_paths(
+    paths: &[DISPLAYCONFIG_PATH_INFO],
+    active_snapshot: &TopologySnapshot,
+) -> i32 {
+    if paths.is_empty() {
+        return -1;
+    }
+    unsafe {
+        SetDisplayConfig(
+            Some(paths),
+            Some(active_snapshot.raw.modes.as_slice()),
+            SDC_VALIDATE | attach_flags(),
+        )
+    }
+}
+
+/// Apply a path array previously accepted by `validate_attach_paths`. Returns the raw status.
+/// NOTE: a 0 here does NOT prove any display came back — SetDisplayConfig returns 0 for a no-op
+/// on an unchanged active set. The caller must confirm against a fresh enumeration.
+pub(super) fn apply_attach_paths(
+    paths: &[DISPLAYCONFIG_PATH_INFO],
+    active_snapshot: &TopologySnapshot,
+) -> i32 {
+    if paths.is_empty() {
+        return -1;
+    }
+    unsafe {
+        SetDisplayConfig(
+            Some(paths),
+            Some(active_snapshot.raw.modes.as_slice()),
+            SDC_APPLY | attach_flags(),
+        )
+    }
+}
+
+/// Ask Windows to replay the last extended configuration from the persistence database.
+/// Returns the raw SetDisplayConfig status and always logs it — including 0, which does NOT mean
+/// the display came back: when the stored entry already matches the current topology this is a
+/// no-op that succeeds. Only the caller knows which target it is chasing, so only the caller can
+/// judge success, by observing a fresh enumeration.
+///
+/// Flag combination verified empirically with SDC_VALIDATE probes (the MSDN claim that
+/// "SDC_ALLOW_CHANGES is allowed with any other valid combination" is FALSE):
+///   EXTEND|ALLOW_CHANGES|SAVE_TO_DATABASE -> 87   (what this code used to send, always)
+///   EXTEND|ALLOW_CHANGES|PERSIST          -> 87
+///   EXTEND|ALLOW_CHANGES                  -> 87
+///   EXTEND|PERSIST                        -> flags accepted
+///   EXTEND                                -> flags accepted
+///   CLONE|ALLOW_CHANGES -> 87  vs  CLONE  -> flags accepted
+/// i.e. SDC_ALLOW_CHANGES is illegal alongside any SDC_TOPOLOGY_*, and SDC_SAVE_TO_DATABASE
+/// requires SDC_USE_SUPPLIED_DISPLAY_CONFIG (documented), which TOPOLOGY_* cannot carry.
+/// SDC_PATH_PERSIST_IF_REQUIRED matters here: a CCD detach clears the target's path persistence,
+/// and without this flag the extend would skip that display.
+pub(super) fn try_topology_extend() -> i32 {
+    let status = unsafe {
         SetDisplayConfig(
             None,
             None,
-            SDC_APPLY | SDC_TOPOLOGY_EXTEND | SDC_ALLOW_CHANGES | SDC_SAVE_TO_DATABASE,
+            SDC_APPLY | SDC_TOPOLOGY_EXTEND | SDC_PATH_PERSIST_IF_REQUIRED,
         )
     };
-    if set_display_status == 0 {
-        return Ok(());
-    }
+    diagnostics::log(format!("apply:sdc_status:{status}:topology_extend"));
+    status
+}
 
-    // Some driver stacks reject direct topology-extend through SetDisplayConfig during
-    // early-login / post-reboot states. Win+P still succeeds there, so fall back to the same
-    // shell path via DisplaySwitch.
-    let display_switch_status = Command::new("DisplaySwitch.exe")
+/// Drive the same shell path Win+P uses. Escalation of last resort, decided by the caller when
+/// the CCD extend did not bring the display back.
+pub(super) fn run_display_switch_extend() -> Result<(), ManagerError> {
+    let display_switch_child = Command::new("DisplaySwitch.exe")
         .creation_flags(CREATE_NO_WINDOW)
         .arg("/extend")
-        .status()
+        .spawn()
         .map_err(|err| {
-            ManagerError::Backend(format!(
-                "SetDisplayConfig (topology extend) failed: {set_display_status}; DisplaySwitch /extend launch failed: {err}"
-            ))
+            ManagerError::Backend(format!("DisplaySwitch /extend launch failed: {err}"))
         })?;
+
+    let Some(display_switch_status) = wait_child_with_timeout(
+        display_switch_child,
+        "DisplaySwitch.exe",
+        Duration::from_secs(10),
+    ) else {
+        return Err(ManagerError::Backend(
+            "DisplaySwitch /extend timed out".to_string(),
+        ));
+    };
 
     if !display_switch_status.success() {
         return Err(ManagerError::Backend(format!(
-            "SetDisplayConfig (topology extend) failed: {set_display_status}; DisplaySwitch /extend failed with exit code {:?}",
+            "DisplaySwitch /extend failed with exit code {:?}",
             display_switch_status.code()
         )));
     }
@@ -257,14 +389,44 @@ fn best_effort_reload_color_calibration() {
 
     // Fallback: trigger Windows' built-in calibration loader task (may fail under standard user
     // task permissions on some machines; that's fine).
-    let _ = Command::new("schtasks.exe")
+    if let Ok(child) = Command::new("schtasks.exe")
         .creation_flags(CREATE_NO_WINDOW)
         .args([
             "/Run",
             "/TN",
             r"\Microsoft\Windows\WindowsColorSystem\Calibration Loader",
         ])
-        .status();
+        .spawn()
+    {
+        let _ = wait_child_with_timeout(child, "schtasks.exe", Duration::from_secs(5));
+    }
+}
+
+/// Poll a child process in 100ms steps until it exits or the timeout elapses. On timeout the
+/// child is killed and `None` is returned, so a wedged helper process can never block an apply
+/// (and with it the global state mutex) indefinitely.
+fn wait_child_with_timeout(mut child: Child, name: &str, timeout: Duration) -> Option<ExitStatus> {
+    let poll_step = Duration::from_millis(100);
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => {}
+            Err(err) => {
+                diagnostics::log(format!("child_wait:error:{name}:{err}"));
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+        if Instant::now() >= deadline {
+            diagnostics::log(format!("child_wait:timeout:{name}"));
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(poll_step);
+    }
 }
 
 fn capture_active_gamma_ramps(snapshot: &TopologySnapshot) -> HashMap<(u64, u32), GammaRampWords> {
@@ -440,6 +602,12 @@ fn apply_desired_source_mode(
     let Some(output) = desired_output.copied() else {
         return;
     };
+    if output.resolution.width == 0 || output.resolution.height == 0 {
+        // Geometry sentinel (a seeded, never-yet-active display): writing 0x0 into the source
+        // mode would make SetDisplayConfig fail with 87 or stack the display on the primary.
+        // Leave the snapshot's real source mode untouched and let Windows place it.
+        return;
+    }
 
     let mode_index = unsafe { path.sourceInfo.Anonymous.modeInfoIdx } as usize;
     let Some(mode) = modes.get_mut(mode_index) else {

--- a/src-tauri/src/backend/windows/enumerate.rs
+++ b/src-tauri/src/backend/windows/enumerate.rs
@@ -9,8 +9,9 @@ use windows::Win32::Devices::Display::{
     DisplayConfigGetDeviceInfo, GetDisplayConfigBufferSizes, QueryDisplayConfig,
     DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME, DISPLAYCONFIG_DEVICE_INFO_HEADER,
     DISPLAYCONFIG_MODE_INFO, DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE,
-    DISPLAYCONFIG_MODE_INFO_TYPE_TARGET, DISPLAYCONFIG_PATH_INFO, DISPLAYCONFIG_TARGET_DEVICE_NAME,
-    DISPLAYCONFIG_ROTATION, DISPLAYCONFIG_ROTATION_ROTATE90, DISPLAYCONFIG_ROTATION_ROTATE270,
+    DISPLAYCONFIG_MODE_INFO_TYPE_TARGET, DISPLAYCONFIG_PATH_INFO, DISPLAYCONFIG_ROTATION,
+    DISPLAYCONFIG_ROTATION_ROTATE270, DISPLAYCONFIG_ROTATION_ROTATE90,
+    DISPLAYCONFIG_TARGET_DEVICE_NAME, DISPLAYCONFIG_TOPOLOGY_ID, QDC_DATABASE_CURRENT,
     QDC_ONLY_ACTIVE_PATHS, QUERY_DISPLAY_CONFIG_FLAGS,
 };
 use windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
@@ -18,39 +19,39 @@ use windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
 use super::win32_types::{luid_to_u64, make_display_id, RawTopologySnapshot, TopologySnapshot};
 
 const DISPLAYCONFIG_PATH_ACTIVE_FLAG: u32 = 0x0000_0001;
-// Query only active paths. The backend cache preserves the richer prior snapshot when needed
-// so we can still re-attach a recently detached display without feeding QDC_ALL_PATHS output
-// directly into SetDisplayConfig (which can produce invalid path sets for our simple toggler).
-const QUERY_FLAGS: QUERY_DISPLAY_CONFIG_FLAGS = QDC_ONLY_ACTIVE_PATHS;
 
 pub fn query_active_topology() -> Result<TopologySnapshot, ManagerError> {
-    let (paths, modes) = query_raw_active()?;
-    let raw = RawTopologySnapshot {
-        paths: paths.clone(),
-        modes: modes.clone(),
-    };
+    let (active_paths, active_modes) = query_raw_active()?;
+    let (paths, modes) = enrich_with_missing_target_paths(
+        active_paths,
+        active_modes,
+        query_raw_database_current().ok(),
+    );
+    snapshot_from_raw(RawTopologySnapshot { paths, modes })
+}
 
+pub(super) fn snapshot_from_raw(
+    raw: RawTopologySnapshot,
+) -> Result<TopologySnapshot, ManagerError> {
     let mut displays = Vec::<DisplayInfo>::new();
     let mut outputs = Vec::new();
+    let mode_map = modes_by_key(&raw.modes);
 
-    let mode_map = modes_by_key(&modes);
-
-    for path in &paths {
-        if path.flags & DISPLAYCONFIG_PATH_ACTIVE_FLAG == 0 {
-            continue;
-        }
+    for path in &raw.paths {
+        let is_active = path.flags & DISPLAYCONFIG_PATH_ACTIVE_FLAG != 0;
 
         let adapter_luid = luid_to_u64(
             path.targetInfo.adapterId.HighPart,
             path.targetInfo.adapterId.LowPart,
         );
-        let (friendly_name, stable_edid_hash) = target_name_and_stable_hash(path)
-            .unwrap_or_else(|_| {
-                (
-                    format!("Display {}:{}", adapter_luid, path.targetInfo.id),
-                    None,
-                )
-            });
+        let (friendly_name, stable_edid_hash) = match target_name_and_stable_hash(path) {
+            Ok(value) => value,
+            Err(_) if is_active => (
+                format!("Display {}:{}", adapter_luid, path.targetInfo.id),
+                None,
+            ),
+            Err(_) => continue,
+        };
         let display_id = make_display_id(adapter_luid, path.targetInfo.id, stable_edid_hash);
 
         let source_key = (
@@ -90,14 +91,14 @@ pub fn query_active_topology() -> Result<TopologySnapshot, ManagerError> {
         let display = DisplayInfo {
             id: display_id,
             friendly_name,
-            is_active: true,
-            is_primary: position.x == 0 && position.y == 0,
+            is_active,
+            is_primary: is_active && position.x == 0 && position.y == 0,
             resolution: display_resolution,
             refresh_rate_mhz,
         };
         outputs.push(OutputConfig {
             display_id: display.id.clone(),
-            enabled: true,
+            enabled: is_active,
             position,
             resolution: source_resolution,
             refresh_rate_mhz: display.refresh_rate_mhz,
@@ -106,11 +107,14 @@ pub fn query_active_topology() -> Result<TopologySnapshot, ManagerError> {
         displays.push(display);
     }
 
-    if !outputs.iter().any(|o| o.primary && o.enabled) {
-        if let Some(first) = outputs.iter_mut().find(|o| o.enabled) {
+    if !outputs
+        .iter()
+        .any(|output| output.primary && output.enabled)
+    {
+        if let Some(first) = outputs.iter_mut().find(|output| output.enabled) {
             first.primary = true;
         }
-        if let Some(first_display) = displays.iter_mut().find(|d| d.is_active) {
+        if let Some(first_display) = displays.iter_mut().find(|display| display.is_active) {
             first_display.is_primary = true;
         }
     }
@@ -122,12 +126,140 @@ pub fn query_active_topology() -> Result<TopologySnapshot, ManagerError> {
     })
 }
 
+fn enrich_with_missing_target_paths(
+    mut base_paths: Vec<DISPLAYCONFIG_PATH_INFO>,
+    mut base_modes: Vec<DISPLAYCONFIG_MODE_INFO>,
+    candidate_raw: Option<(Vec<DISPLAYCONFIG_PATH_INFO>, Vec<DISPLAYCONFIG_MODE_INFO>)>,
+) -> (Vec<DISPLAYCONFIG_PATH_INFO>, Vec<DISPLAYCONFIG_MODE_INFO>) {
+    let Some((candidate_paths, candidate_modes)) = candidate_raw else {
+        return (base_paths, base_modes);
+    };
+
+    let mut known_targets = base_paths
+        .iter()
+        .map(path_target_identity)
+        .collect::<std::collections::HashSet<_>>();
+    let mut mode_index = base_modes
+        .iter()
+        .enumerate()
+        .map(|(idx, mode)| (mode_identity(mode), idx as u32))
+        .collect::<HashMap<_, _>>();
+
+    for candidate in candidate_paths {
+        let target_identity = path_target_identity(&candidate);
+        if known_targets.contains(&target_identity) {
+            continue;
+        }
+        if target_name_and_stable_hash(&candidate).is_err() {
+            continue;
+        }
+        if !candidate_path_is_attachable(&candidate, &candidate_modes) {
+            continue;
+        }
+
+        let mut next_path = candidate;
+        unsafe {
+            let source_idx = next_path.sourceInfo.Anonymous.modeInfoIdx;
+            let remapped_source_idx = remap_mode_index(
+                source_idx,
+                &candidate_modes,
+                &mut base_modes,
+                &mut mode_index,
+            );
+            next_path.sourceInfo.Anonymous.modeInfoIdx = remapped_source_idx;
+        }
+        unsafe {
+            let target_idx = next_path.targetInfo.Anonymous.modeInfoIdx;
+            let remapped_target_idx = remap_mode_index(
+                target_idx,
+                &candidate_modes,
+                &mut base_modes,
+                &mut mode_index,
+            );
+            next_path.targetInfo.Anonymous.modeInfoIdx = remapped_target_idx;
+        }
+
+        base_paths.push(next_path);
+        known_targets.insert(target_identity);
+    }
+
+    (base_paths, base_modes)
+}
+
+fn candidate_path_is_attachable(
+    candidate: &DISPLAYCONFIG_PATH_INFO,
+    candidate_modes: &[DISPLAYCONFIG_MODE_INFO],
+) -> bool {
+    let source_idx = unsafe { candidate.sourceInfo.Anonymous.modeInfoIdx };
+    let Some(source_mode) = candidate_modes.get(source_idx as usize) else {
+        return false;
+    };
+    if source_mode.infoType.0 != DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE.0 {
+        return false;
+    }
+    let Ok((_, resolution)) = source_mode_position_and_resolution(source_mode) else {
+        return false;
+    };
+    if resolution.width == 0 || resolution.height == 0 {
+        return false;
+    }
+
+    let target_idx = unsafe { candidate.targetInfo.Anonymous.modeInfoIdx };
+    if target_idx == u32::MAX {
+        return true;
+    }
+    let Some(target_mode) = candidate_modes.get(target_idx as usize) else {
+        return false;
+    };
+    target_mode.infoType.0 == DISPLAYCONFIG_MODE_INFO_TYPE_TARGET.0
+}
+
+fn remap_mode_index(
+    original_idx: u32,
+    source_modes: &[DISPLAYCONFIG_MODE_INFO],
+    base_modes: &mut Vec<DISPLAYCONFIG_MODE_INFO>,
+    mode_index: &mut HashMap<(i32, u32, u32, u32), u32>,
+) -> u32 {
+    if original_idx == u32::MAX {
+        return u32::MAX;
+    }
+    let Some(mode) = source_modes.get(original_idx as usize) else {
+        return u32::MAX;
+    };
+
+    let identity = mode_identity(mode);
+    if let Some(existing) = mode_index.get(&identity) {
+        return *existing;
+    }
+
+    let next_idx = base_modes.len() as u32;
+    base_modes.push(mode.clone());
+    mode_index.insert(identity, next_idx);
+    next_idx
+}
+
+fn mode_identity(mode: &DISPLAYCONFIG_MODE_INFO) -> (i32, u32, u32, u32) {
+    (
+        mode.adapterId.HighPart,
+        mode.adapterId.LowPart,
+        mode.id,
+        mode.infoType.0 as u32,
+    )
+}
+
+fn path_target_identity(path: &DISPLAYCONFIG_PATH_INFO) -> (i32, u32, u32) {
+    (
+        path.targetInfo.adapterId.HighPart,
+        path.targetInfo.adapterId.LowPart,
+        path.targetInfo.id,
+    )
+}
+
 fn effective_resolution_for_rotation(
     source_resolution: Resolution,
     rotation: DISPLAYCONFIG_ROTATION,
 ) -> Resolution {
-    if rotation == DISPLAYCONFIG_ROTATION_ROTATE90 || rotation == DISPLAYCONFIG_ROTATION_ROTATE270
-    {
+    if rotation == DISPLAYCONFIG_ROTATION_ROTATE90 || rotation == DISPLAYCONFIG_ROTATION_ROTATE270 {
         return Resolution {
             width: source_resolution.height,
             height: source_resolution.width,
@@ -138,11 +270,23 @@ fn effective_resolution_for_rotation(
 
 fn query_raw_active(
 ) -> Result<(Vec<DISPLAYCONFIG_PATH_INFO>, Vec<DISPLAYCONFIG_MODE_INFO>), ManagerError> {
+    query_raw_with_flags(QDC_ONLY_ACTIVE_PATHS, false)
+}
+
+fn query_raw_database_current(
+) -> Result<(Vec<DISPLAYCONFIG_PATH_INFO>, Vec<DISPLAYCONFIG_MODE_INFO>), ManagerError> {
+    query_raw_with_flags(QDC_DATABASE_CURRENT, true)
+}
+
+fn query_raw_with_flags(
+    query_flags: QUERY_DISPLAY_CONFIG_FLAGS,
+    needs_topology_id: bool,
+) -> Result<(Vec<DISPLAYCONFIG_PATH_INFO>, Vec<DISPLAYCONFIG_MODE_INFO>), ManagerError> {
     unsafe {
         let mut path_count = 0u32;
         let mut mode_count = 0u32;
 
-        let mut status = GetDisplayConfigBufferSizes(QUERY_FLAGS, &mut path_count, &mut mode_count);
+        let mut status = GetDisplayConfigBufferSizes(query_flags, &mut path_count, &mut mode_count);
         if status.0 != 0 {
             return Err(ManagerError::Backend(format!(
                 "GetDisplayConfigBufferSizes failed: {}",
@@ -156,19 +300,24 @@ fn query_raw_active(
 
             let mut out_paths = path_count;
             let mut out_modes = mode_count;
+            let mut topology_id = DISPLAYCONFIG_TOPOLOGY_ID(0);
 
             status = QueryDisplayConfig(
-                QUERY_FLAGS,
+                query_flags,
                 &mut out_paths,
                 paths.as_mut_ptr(),
                 &mut out_modes,
                 modes.as_mut_ptr(),
-                None,
+                if needs_topology_id {
+                    Some(&mut topology_id)
+                } else {
+                    None
+                },
             );
 
             if status == ERROR_INSUFFICIENT_BUFFER {
                 let retry =
-                    GetDisplayConfigBufferSizes(QUERY_FLAGS, &mut path_count, &mut mode_count);
+                    GetDisplayConfigBufferSizes(query_flags, &mut path_count, &mut mode_count);
                 if retry.0 != 0 {
                     return Err(ManagerError::Backend(format!(
                         "GetDisplayConfigBufferSizes retry failed: {}",

--- a/src-tauri/src/backend/windows/enumerate.rs
+++ b/src-tauri/src/backend/windows/enumerate.rs
@@ -3,7 +3,9 @@
 use std::collections::HashMap;
 use std::hash::Hasher;
 use std::mem::size_of;
+use std::sync::{Mutex, OnceLock};
 
+use crate::diagnostics;
 use monarch::{DisplayInfo, Layout, ManagerError, OutputConfig, Position, Resolution};
 use windows::Win32::Devices::Display::{
     DisplayConfigGetDeviceInfo, GetDisplayConfigBufferSizes, QueryDisplayConfig,
@@ -11,22 +13,192 @@ use windows::Win32::Devices::Display::{
     DISPLAYCONFIG_MODE_INFO, DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE,
     DISPLAYCONFIG_MODE_INFO_TYPE_TARGET, DISPLAYCONFIG_PATH_INFO, DISPLAYCONFIG_ROTATION,
     DISPLAYCONFIG_ROTATION_ROTATE270, DISPLAYCONFIG_ROTATION_ROTATE90,
-    DISPLAYCONFIG_TARGET_DEVICE_NAME, DISPLAYCONFIG_TOPOLOGY_ID, QDC_DATABASE_CURRENT,
-    QDC_ONLY_ACTIVE_PATHS, QUERY_DISPLAY_CONFIG_FLAGS,
+    DISPLAYCONFIG_TARGET_DEVICE_NAME, DISPLAYCONFIG_TOPOLOGY_ID, QDC_ALL_PATHS,
+    QDC_DATABASE_CURRENT, QDC_ONLY_ACTIVE_PATHS, QUERY_DISPLAY_CONFIG_FLAGS,
 };
 use windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
 
-use super::win32_types::{luid_to_u64, make_display_id, RawTopologySnapshot, TopologySnapshot};
+use super::win32_types::{
+    luid_to_u64, make_display_id, AttachablePath, RawTopologySnapshot, TopologySnapshot,
+};
 
 const DISPLAYCONFIG_PATH_ACTIVE_FLAG: u32 = 0x0000_0001;
 
+/// Per-enumeration observability counters. Logged (prefix "enum:") only when the resulting
+/// summary changes, because the watchdogs enumerate every 1.2s/1.8s.
+#[derive(Default)]
+struct EnumerationStats {
+    active_paths: usize,
+    db_paths: usize,
+    enriched: Vec<String>,
+    seeded: Vec<String>,
+    discarded: Vec<String>,
+}
+
 pub fn query_active_topology() -> Result<TopologySnapshot, ManagerError> {
+    let mut stats = EnumerationStats::default();
     let (active_paths, active_modes) = query_raw_active()?;
-    let (paths, modes) = enrich_with_missing_target_paths(
-        active_paths,
-        active_modes,
-        query_raw_database_current().ok(),
+    stats.active_paths = active_paths.len();
+    let db_raw = query_raw_database_current().ok();
+    stats.db_paths = db_raw.as_ref().map(|(paths, _)| paths.len()).unwrap_or(0);
+    let (paths, modes) =
+        enrich_with_missing_target_paths(active_paths, active_modes, db_raw, &mut stats);
+    let mut snapshot = snapshot_from_raw(RawTopologySnapshot { paths, modes })?;
+    seed_connected_inactive_displays(&mut snapshot, &mut stats);
+    log_enumeration_if_changed(&stats);
+    Ok(snapshot)
+}
+
+fn log_enumeration_if_changed(stats: &EnumerationStats) {
+    let line = format!(
+        "enum:active={}:db={}:enriched=[{}]:seeded=[{}]:discarded=[{}]",
+        stats.active_paths,
+        stats.db_paths,
+        stats.enriched.join(", "),
+        stats.seeded.join(", "),
+        stats.discarded.join(", ")
     );
+
+    static LAST: OnceLock<Mutex<String>> = OnceLock::new();
+    let last = LAST.get_or_init(|| Mutex::new(String::new()));
+    let Ok(mut last) = last.lock() else {
+        return;
+    };
+    if *last != line {
+        *last = line.clone();
+        diagnostics::log(line);
+    }
+}
+
+/// Make connected-but-inactive displays visible even when QDC_DATABASE_CURRENT enrichment did
+/// not surface their paths (seen in the field: a detached TV visible in Windows Display settings
+/// but absent from the database query). QDC_ALL_PATHS lists every source combination for every
+/// connected target; each yet-unrepresented connected target is added as display info, and its
+/// paths are kept in `snapshot.attachable` so the recovery can activate it explicitly.
+/// Those paths are deliberately NOT added to `snapshot.raw`, which is the current configuration
+/// and goes straight to SetDisplayConfig on every apply.
+fn seed_connected_inactive_displays(snapshot: &mut TopologySnapshot, stats: &mut EnumerationStats) {
+    let Ok((all_paths, all_modes)) = query_raw_with_flags(QDC_ALL_PATHS, false) else {
+        return;
+    };
+    let mode_map = modes_by_key(&all_modes);
+
+    let mut known_connectors = snapshot
+        .displays
+        .iter()
+        .map(|display| (display.id.adapter_luid, display.id.target_id))
+        .collect::<std::collections::HashSet<_>>();
+    let mut known_edids = snapshot
+        .displays
+        .iter()
+        .filter_map(|display| display.id.edid_hash)
+        .collect::<std::collections::HashSet<_>>();
+    let mut seeded_connectors = std::collections::HashSet::new();
+
+    for path in &all_paths {
+        let adapter_luid = luid_to_u64(
+            path.targetInfo.adapterId.HighPart,
+            path.targetInfo.adapterId.LowPart,
+        );
+        let connector = (adapter_luid, path.targetInfo.id);
+        if known_connectors.contains(&connector) {
+            // ALL_PATHS yields one entry per source combination; connectors already represented
+            // (active, enriched or seeded by an earlier combination) are the normal case.
+            continue;
+        }
+        // Every branch below decides this connector once; never revisit later combinations.
+        known_connectors.insert(connector);
+
+        if !path.targetInfo.targetAvailable.as_bool() {
+            stats
+                .discarded
+                .push(format!("target={}:unavailable", path.targetInfo.id));
+            continue;
+        }
+        let Ok((friendly_name, edid_hash)) = target_name_and_stable_hash(path) else {
+            stats
+                .discarded
+                .push(format!("target={}:name-fail", path.targetInfo.id));
+            continue;
+        };
+        if let Some(hash) = edid_hash {
+            if known_edids.contains(&hash) {
+                stats
+                    .discarded
+                    .push(format!("target={}:dedupe", path.targetInfo.id));
+                continue;
+            }
+            known_edids.insert(hash);
+        }
+
+        // Best-effort refresh rate: the target mode key is specific to this target, so a hit
+        // genuinely belongs to this display.
+        let target_key = (
+            path.targetInfo.adapterId.HighPart,
+            path.targetInfo.adapterId.LowPart,
+            path.targetInfo.id,
+            DISPLAYCONFIG_MODE_INFO_TYPE_TARGET.0 as u32,
+        );
+        let refresh_rate_mhz = mode_map
+            .get(&target_key)
+            .and_then(|mode| target_mode_refresh_mhz(mode).ok())
+            .unwrap_or(60_000);
+        // Resolution/position are deliberately a 0x0 sentinel: QDC_ALL_PATHS only carries modes
+        // for ACTIVE paths, so a source-mode lookup here would alias another display's geometry
+        // (the source id of an inactive path points at a source that belongs to whoever is
+        // currently driving it). Downstream, the cache merge restores the last real geometry and
+        // the attach recovery fills it from the post-extend snapshot.
+        let resolution = Resolution {
+            width: 0,
+            height: 0,
+        };
+
+        let display_id = make_display_id(adapter_luid, path.targetInfo.id, edid_hash);
+        stats
+            .seeded
+            .push(format!("'{friendly_name}':{}", path.targetInfo.id));
+        seeded_connectors.insert(connector);
+        snapshot.layout.outputs.push(OutputConfig {
+            display_id: display_id.clone(),
+            enabled: false,
+            position: Position { x: 0, y: 0 },
+            resolution: resolution.clone(),
+            refresh_rate_mhz,
+            primary: false,
+        });
+        snapshot.displays.push(DisplayInfo {
+            id: display_id,
+            friendly_name,
+            is_active: false,
+            is_primary: false,
+            resolution,
+            refresh_rate_mhz,
+        });
+    }
+
+    // Keep every (source, target) combination for the seeded targets: the source is only picked
+    // at attach time, and it must be one that is currently free (a busy source would clone).
+    for path in &all_paths {
+        let adapter_luid = luid_to_u64(
+            path.targetInfo.adapterId.HighPart,
+            path.targetInfo.adapterId.LowPart,
+        );
+        let connector = (adapter_luid, path.targetInfo.id);
+        if !seeded_connectors.contains(&connector) {
+            continue;
+        }
+        snapshot.attachable.push(AttachablePath {
+            path: *path,
+            adapter_luid,
+            target_id: path.targetInfo.id,
+        });
+    }
+}
+
+/// Active-only snapshot without QDC_DATABASE_CURRENT enrichment. Used as the base for
+/// detach-only applies so database-sourced paths are never fed back into SetDisplayConfig.
+pub(super) fn query_active_only_topology() -> Result<TopologySnapshot, ManagerError> {
+    let (paths, modes) = query_raw_active()?;
     snapshot_from_raw(RawTopologySnapshot { paths, modes })
 }
 
@@ -123,6 +295,7 @@ pub(super) fn snapshot_from_raw(
         raw,
         layout: Layout { outputs },
         displays,
+        attachable: Vec::new(),
     })
 }
 
@@ -130,6 +303,7 @@ fn enrich_with_missing_target_paths(
     mut base_paths: Vec<DISPLAYCONFIG_PATH_INFO>,
     mut base_modes: Vec<DISPLAYCONFIG_MODE_INFO>,
     candidate_raw: Option<(Vec<DISPLAYCONFIG_PATH_INFO>, Vec<DISPLAYCONFIG_MODE_INFO>)>,
+    stats: &mut EnumerationStats,
 ) -> (Vec<DISPLAYCONFIG_PATH_INFO>, Vec<DISPLAYCONFIG_MODE_INFO>) {
     let Some((candidate_paths, candidate_modes)) = candidate_raw else {
         return (base_paths, base_modes);
@@ -148,14 +322,24 @@ fn enrich_with_missing_target_paths(
     for candidate in candidate_paths {
         let target_identity = path_target_identity(&candidate);
         if known_targets.contains(&target_identity) {
+            // Normal case: every active target also shows up in the database query.
             continue;
         }
-        if target_name_and_stable_hash(&candidate).is_err() {
+        let Ok((candidate_name, _)) = target_name_and_stable_hash(&candidate) else {
+            stats
+                .discarded
+                .push(format!("target={}:name-fail", candidate.targetInfo.id));
             continue;
-        }
+        };
         if !candidate_path_is_attachable(&candidate, &candidate_modes) {
+            stats
+                .discarded
+                .push(format!("target={}:not-attachable", candidate.targetInfo.id));
             continue;
         }
+        stats
+            .enriched
+            .push(format!("'{candidate_name}':{}", candidate.targetInfo.id));
 
         let mut next_path = candidate;
         unsafe {

--- a/src-tauri/src/backend/windows/topology.rs
+++ b/src-tauri/src/backend/windows/topology.rs
@@ -6,16 +6,16 @@ use std::mem::{size_of, MaybeUninit};
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+use crate::diagnostics;
 use monarch::{DisplayBackend, DisplayId, DisplayInfo, Layout, ManagerError};
 use serde::{Deserialize, Serialize};
 
 use super::apply::{
     active_color_state_signature, apply_layout_against_snapshot, capture_sdr_gamma_ramps,
     force_topology_extend, gamma_ramp_looks_identity,
-    reapply_color_calibration_for_active_with_cached_sdr,
-    GammaRampKey, GammaRampWords,
+    reapply_color_calibration_for_active_with_cached_sdr, GammaRampKey, GammaRampWords,
 };
-use super::enumerate::query_active_topology;
+use super::enumerate::{query_active_topology, snapshot_from_raw};
 use super::win32_types::{RawTopologySnapshot, TopologySnapshot};
 
 const PERSISTED_RAW_SNAPSHOT_VERSION: u32 = 1;
@@ -79,58 +79,11 @@ impl WindowsDisplayBackend {
             cache.last_snapshot.as_ref(),
             snapshot.clone(),
         ));
-
-        let mut merged_layout = cache
-            .last_layout
-            .clone()
-            .unwrap_or_else(|| snapshot.layout.clone());
-        for output in &mut merged_layout.outputs {
-            if let Some(active) = snapshot
-                .layout
-                .outputs
-                .iter()
-                .find(|active| active.display_id == output.display_id)
-            {
-                *output = active.clone();
-            } else {
-                output.enabled = false;
-                output.primary = false;
-            }
-        }
-        for active in &snapshot.layout.outputs {
-            if !merged_layout
-                .outputs
-                .iter()
-                .any(|o| o.display_id == active.display_id)
-            {
-                merged_layout.outputs.push(active.clone());
-            }
-        }
-        if !merged_layout.outputs.iter().any(|o| o.enabled && o.primary) {
-            if let Some(first) = merged_layout.outputs.iter_mut().find(|o| o.enabled) {
-                first.primary = true;
-            }
-        }
-        cache.last_layout = Some(merged_layout);
-
-        for display in &mut cache.last_displays {
-            if let Some(active) = snapshot.displays.iter().find(|d| d.id == display.id) {
-                *display = active.clone();
-            } else {
-                display.is_active = false;
-                display.is_primary = false;
-            }
-        }
-        for active in &snapshot.displays {
-            if !cache.last_displays.iter().any(|d| d.id == active.id) {
-                cache.last_displays.push(active.clone());
-            }
-        }
-        cache.last_displays.sort_by(|a, b| {
-            a.friendly_name
-                .cmp(&b.friendly_name)
-                .then(a.id.target_id.cmp(&b.id.target_id))
-        });
+        cache.last_layout = Some(merge_layout_with_fresh(
+            cache.last_layout.as_ref(),
+            &snapshot.layout,
+        ));
+        cache.last_displays = merge_displays_with_fresh(&cache.last_displays, &snapshot.displays);
         Ok(())
     }
 
@@ -195,9 +148,15 @@ fn merge_persisted_raw_for_fresh(
         return fresh;
     }
 
-    let mut merged = fresh;
-    merged.raw = persisted_raw.clone();
-    merged
+    let Ok(persisted_snapshot) = snapshot_from_raw(persisted_raw.clone()) else {
+        return fresh;
+    };
+
+    TopologySnapshot {
+        raw: persisted_snapshot.raw,
+        layout: merge_layout_with_fresh(Some(&persisted_snapshot.layout), &fresh.layout),
+        displays: merge_displays_with_fresh(&persisted_snapshot.displays, &fresh.displays),
+    }
 }
 
 fn raw_covers_active_outputs_raw(raw: &RawTopologySnapshot, layout: &Layout) -> bool {
@@ -213,6 +172,64 @@ fn raw_covers_active_outputs_raw(raw: &RawTopologySnapshot, layout: &Layout) -> 
                     && path.targetInfo.id == output.display_id.target_id
             })
         })
+}
+
+fn merge_layout_with_fresh(previous: Option<&Layout>, fresh: &Layout) -> Layout {
+    let mut merged = previous.cloned().unwrap_or_else(|| fresh.clone());
+    for output in &mut merged.outputs {
+        if let Some(active) = fresh
+            .outputs
+            .iter()
+            .find(|active| active.display_id == output.display_id)
+        {
+            *output = active.clone();
+        } else {
+            output.enabled = false;
+            output.primary = false;
+        }
+    }
+    for active in &fresh.outputs {
+        if !merged
+            .outputs
+            .iter()
+            .any(|output| output.display_id == active.display_id)
+        {
+            merged.outputs.push(active.clone());
+        }
+    }
+    if !merged
+        .outputs
+        .iter()
+        .any(|output| output.enabled && output.primary)
+    {
+        if let Some(first) = merged.outputs.iter_mut().find(|output| output.enabled) {
+            first.primary = true;
+        }
+    }
+    merged
+}
+
+fn merge_displays_with_fresh(previous: &[DisplayInfo], fresh: &[DisplayInfo]) -> Vec<DisplayInfo> {
+    let mut merged = previous.to_vec();
+    for display in &mut merged {
+        if let Some(active) = fresh.iter().find(|active| active.id == display.id) {
+            *display = active.clone();
+        } else {
+            display.is_active = false;
+            display.is_primary = false;
+        }
+    }
+    for active in fresh {
+        if !merged.iter().any(|display| display.id == active.id) {
+            merged.push(active.clone());
+        }
+    }
+    merged.sort_by(|left, right| {
+        left.friendly_name
+            .cmp(&right.friendly_name)
+            .then(left.id.target_id.cmp(&right.id.target_id))
+    });
+    merged
 }
 
 impl DisplayBackend for WindowsDisplayBackend {
@@ -239,6 +256,10 @@ impl DisplayBackend for WindowsDisplayBackend {
 
     fn apply_layout(&self, layout: Layout) -> Result<(), ManagerError> {
         layout.ensure_valid()?;
+        diagnostics::log(format!(
+            "topology_apply:start:outputs={}",
+            layout.outputs.len()
+        ));
 
         // Re-query the currently active topology so detach-only operations use a minimal base.
         // This reduces the chance of Windows re-touching unrelated outputs.
@@ -269,24 +290,28 @@ impl DisplayBackend for WindowsDisplayBackend {
             match apply_layout_against_snapshot(&working_layout, &base_snapshot) {
                 Ok(snapshot) => (snapshot, working_layout),
                 Err(error) if is_set_display_invalid_parameter(&error) => {
+                    diagnostics::log("topology_apply:retry:reason=setdisplayconfig_87");
                     force_topology_extend()?;
                     std::thread::sleep(std::time::Duration::from_millis(700));
                     let recovered_snapshot = query_active_topology()?;
-                    let retry_layout =
-                        remap_layout_display_ids_for_snapshot(&working_layout, &recovered_snapshot.layout);
-                    let snapshot = apply_layout_against_snapshot(&retry_layout, &recovered_snapshot)?;
+                    let retry_layout = remap_layout_display_ids_for_snapshot(
+                        &working_layout,
+                        &recovered_snapshot.layout,
+                    );
+                    let snapshot =
+                        apply_layout_against_snapshot(&retry_layout, &recovered_snapshot)?;
                     (snapshot, retry_layout)
                 }
-                Err(error) => return Err(error),
+                Err(error) => {
+                    diagnostics::log(format!("topology_apply:error:{error}"));
+                    return Err(error);
+                }
             };
         let mut cache = self
             .cache
             .lock()
             .map_err(|_| ManagerError::Backend("windows backend cache poisoned".to_string()))?;
-        let merged_snapshot = merge_snapshot_for_cache(
-            Some(&base_snapshot),
-            next_snapshot.clone(),
-        );
+        let merged_snapshot = merge_snapshot_for_cache(Some(&base_snapshot), next_snapshot.clone());
         let raw_to_persist = merged_snapshot.raw.clone();
         cache.last_snapshot = Some(merged_snapshot);
         merge_sdr_gamma_cache(
@@ -328,6 +353,7 @@ impl DisplayBackend for WindowsDisplayBackend {
         cache.last_displays = displays;
         drop(cache);
         best_effort_persist_raw_snapshot(&raw_to_persist);
+        diagnostics::log("topology_apply:done");
 
         Ok(())
     }
@@ -406,16 +432,21 @@ fn remap_layout_display_ids_for_snapshot(desired: &Layout, current: &Layout) -> 
         let mut replacement = None;
 
         if let Some(edid_hash) = output.display_id.edid_hash {
-            let candidates =
-                unique_unused_candidates(current_by_edid.get(&edid_hash).cloned().unwrap_or_default(), &used);
+            let candidates = unique_unused_candidates(
+                current_by_edid.get(&edid_hash).cloned().unwrap_or_default(),
+                &used,
+            );
             if candidates.len() == 1 {
                 replacement = Some(candidates[0].display_id.clone());
             }
         }
 
-        if replacement.is_none() {
-            let candidates =
-                unique_unused_candidates_by_target_id(output.display_id.target_id, &current.outputs, &used);
+        if replacement.is_none() && output.display_id.edid_hash.is_none() {
+            let candidates = unique_unused_candidates_by_target_id(
+                output.display_id.target_id,
+                &current.outputs,
+                &used,
+            );
             if candidates.len() == 1 {
                 replacement = Some(candidates[0].display_id.clone());
             }
@@ -477,7 +508,9 @@ fn persist_raw_snapshot(raw: &RawTopologySnapshot) -> Result<(), ManagerError> {
     let path = persisted_raw_snapshot_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|err| {
-            ManagerError::Backend(format!("failed to create persisted snapshot directory: {err}"))
+            ManagerError::Backend(format!(
+                "failed to create persisted snapshot directory: {err}"
+            ))
         })?;
     }
 
@@ -505,16 +538,16 @@ fn load_persisted_raw_snapshot() -> Option<RawTopologySnapshot> {
 
     let mut paths = Vec::with_capacity(payload.paths.len());
     for bytes in payload.paths {
-        paths.push(struct_from_bytes::<windows::Win32::Devices::Display::DISPLAYCONFIG_PATH_INFO>(
-            &bytes,
-        )?);
+        paths.push(struct_from_bytes::<
+            windows::Win32::Devices::Display::DISPLAYCONFIG_PATH_INFO,
+        >(&bytes)?);
     }
 
     let mut modes = Vec::with_capacity(payload.modes.len());
     for bytes in payload.modes {
-        modes.push(struct_from_bytes::<windows::Win32::Devices::Display::DISPLAYCONFIG_MODE_INFO>(
-            &bytes,
-        )?);
+        modes.push(struct_from_bytes::<
+            windows::Win32::Devices::Display::DISPLAYCONFIG_MODE_INFO,
+        >(&bytes)?);
     }
 
     Some(RawTopologySnapshot { paths, modes })
@@ -539,11 +572,7 @@ fn struct_from_bytes<T>(bytes: &[u8]) -> Option<T> {
 
     let mut value = MaybeUninit::<T>::uninit();
     unsafe {
-        std::ptr::copy_nonoverlapping(
-            bytes.as_ptr(),
-            value.as_mut_ptr().cast::<u8>(),
-            bytes.len(),
-        );
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), value.as_mut_ptr().cast::<u8>(), bytes.len());
         Some(value.assume_init())
     }
 }

--- a/src-tauri/src/backend/windows/topology.rs
+++ b/src-tauri/src/backend/windows/topology.rs
@@ -11,14 +11,16 @@ use monarch::{DisplayBackend, DisplayId, DisplayInfo, Layout, ManagerError};
 use serde::{Deserialize, Serialize};
 
 use super::apply::{
-    active_color_state_signature, apply_layout_against_snapshot, capture_sdr_gamma_ramps,
-    force_topology_extend, gamma_ramp_looks_identity,
-    reapply_color_calibration_for_active_with_cached_sdr, GammaRampKey, GammaRampWords,
+    active_color_state_signature, apply_attach_paths, apply_layout_against_snapshot,
+    build_attach_paths, capture_sdr_gamma_ramps, gamma_ramp_looks_identity,
+    reapply_color_calibration_for_active_with_cached_sdr, run_display_switch_extend,
+    try_topology_extend, validate_attach_paths, GammaRampKey, GammaRampWords,
 };
-use super::enumerate::{query_active_topology, snapshot_from_raw};
-use super::win32_types::{RawTopologySnapshot, TopologySnapshot};
+use super::enumerate::{query_active_only_topology, query_active_topology, snapshot_from_raw};
+use super::win32_types::{luid_to_u64, AttachablePath, RawTopologySnapshot, TopologySnapshot};
 
 const PERSISTED_RAW_SNAPSHOT_VERSION: u32 = 1;
+const DISPLAYCONFIG_PATH_ACTIVE_FLAG: u32 = 0x0000_0001;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct PersistedRawSnapshot {
@@ -35,6 +37,10 @@ struct BackendCache {
     last_layout: Option<Layout>,
     last_displays: Vec<DisplayInfo>,
     sdr_gamma_cache: HashMap<GammaRampKey, GammaRampWords>,
+    /// Set by `invalidate_cache`: the next refresh re-seeds detached-display knowledge from the
+    /// persisted snapshot (when it still matches this boot), so an invalidation does not lose a
+    /// detached display whenever QDC_DATABASE_CURRENT enrichment fails afterwards.
+    reseed_persisted: bool,
 }
 
 #[derive(Default)]
@@ -45,12 +51,41 @@ pub struct WindowsDisplayBackend {
 impl WindowsDisplayBackend {
     pub fn new() -> Result<Self, ManagerError> {
         let backend = Self::default();
+        let mut persist_now = true;
         let snapshot = {
             let fresh = query_active_topology()?;
-            if let Some(persisted_raw) = load_persisted_raw_snapshot() {
-                merge_persisted_raw_for_fresh(fresh, &persisted_raw)
-            } else {
-                fresh
+            match load_persisted_raw_snapshot() {
+                Some(persisted_raw) if persisted_raw.paths.len() > fresh.raw.paths.len() => {
+                    match merge_persisted_raw_for_fresh(&fresh, &persisted_raw) {
+                        Some(merged) => merged,
+                        None => {
+                            // Two very different causes land here, and only one justifies a
+                            // rewrite:
+                            //  (a) no connector in common -> adapter LUID churn across a reboot.
+                            //      The file describes a boot that no longer exists and never will
+                            //      again: a fossil. Overwrite it, or it blocks forever — the only
+                            //      other writer is a successful apply, which a stale snapshot can
+                            //      itself block.
+                            //  (b) connectors still overlap -> the LUIDs are current and the
+                            //      active set simply changed (e.g. the user attached something
+                            //      from Windows Display settings). The persisted paths of the
+                            //      OTHER connectors are still real and may be the last record of
+                            //      a detached display, so keep them: a kept fossil is inert (this
+                            //      session uses `fresh` and the merge re-rejects it), a destroyed
+                            //      one never comes back.
+                            let persisted_connectors = raw_path_connectors(&persisted_raw);
+                            let fresh_connectors = raw_path_connectors(&fresh.raw);
+                            persist_now = persisted_connectors.is_disjoint(&fresh_connectors);
+                            diagnostics::log(if persist_now {
+                                "topology_persist:replace:persisted_snapshot_from_another_boot"
+                            } else {
+                                "topology_persist:keep:persisted_snapshot_rejected_but_current"
+                            });
+                            fresh
+                        }
+                    }
+                }
+                _ => fresh,
             }
         };
         let initial_sdr_ramps = capture_sdr_gamma_ramps(&snapshot);
@@ -64,16 +99,100 @@ impl WindowsDisplayBackend {
         cache.last_snapshot = Some(snapshot);
         merge_sdr_gamma_cache(&mut cache.sdr_gamma_cache, initial_sdr_ramps);
         drop(cache);
-        best_effort_persist_raw_snapshot(&raw_to_persist);
+        if persist_now {
+            best_effort_persist_raw_snapshot(&raw_to_persist);
+        }
         Ok(backend)
     }
 
-    fn refresh_active(&self) -> Result<(), ManagerError> {
-        let snapshot = query_active_topology()?;
+    /// Drop every cached snapshot/layout/display entry (the SDR gamma cache is kept) so the next
+    /// refresh rebuilds state from a fresh enriched enumeration. Used after system resume, when
+    /// stale adapter LUIDs and transient EDID read failures would otherwise pollute the cache.
+    pub fn invalidate_cache(&self) -> Result<(), ManagerError> {
         let mut cache = self
             .cache
             .lock()
             .map_err(|_| ManagerError::Backend("windows backend cache poisoned".to_string()))?;
+        cache.last_snapshot = None;
+        cache.last_layout = None;
+        cache.last_displays.clear();
+        cache.reseed_persisted = true;
+        drop(cache);
+        diagnostics::log("backend_cache:invalidated");
+        Ok(())
+    }
+
+    /// Diagnostic hook the manager calls before rejecting a profile/restore whose enabled outputs
+    /// do not resolve. It deliberately does NOT touch the topology: nothing it could do would
+    /// help, so all it does is record WHY the display is unusable.
+    ///
+    /// Why no rescue is possible here: resolving means the display is ENUMERATED, not that it is
+    /// active. The QDC_ALL_PATHS seeder already puts every connected-but-detached display in the
+    /// layout (as `is_active=false`), so anything attachable already resolves; conversely an
+    /// output that does NOT resolve names a display Windows is not enumerating at all — powered
+    /// off, unplugged, or reported with `targetAvailable=FALSE`. Neither rescue can conjure that:
+    /// an explicit attach only raises the ACTIVE flag on a path that must already exist, and
+    /// SDC_TOPOLOGY_EXTEND replays the persistence database. (Attaching a display that is
+    /// enumerated under a different identity than the profile expects would not make the profile
+    /// resolve either — it would just move the user's screens for nothing.)
+    ///
+    /// This used to force an extend. In the field that only produced an unrequested topology flip
+    /// — attaching every connected-inactive display, including a TV the user had just asked the
+    /// profile to DETACH — plus a 3.5s stall, before failing anyway with ERROR_GEN_FAILURE.
+    pub fn prepare_attach_targets(&self, desired: &Layout) -> Result<(), ManagerError> {
+        let snapshot = query_active_topology()?;
+        let unresolved = unresolved_enabled_outputs(desired, &snapshot);
+        if unresolved.is_empty() {
+            return Ok(());
+        }
+
+        let used_source_keys = active_source_keys(&snapshot);
+        for output in &unresolved {
+            let description = describe_output_for_error(output, &snapshot);
+            let candidates = select_attach_candidates(
+                &snapshot.attachable,
+                &output.display_id,
+                &used_source_keys,
+            );
+            if candidates.is_empty() {
+                diagnostics::log(format!(
+                    "prepare_attach_targets:no_candidate:{description}:skip_extend"
+                ));
+            } else {
+                // Canary: an attach candidate for an output that does not resolve means the
+                // connector now carries a display with a different identity than the profile
+                // expects (its EDID changed). Attaching it would not make the profile resolve,
+                // so the topology is still left alone.
+                diagnostics::log(format!(
+                    "prepare_attach_targets:candidate_for_unresolved_output:{description}:skip_extend"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn refresh_active(&self) -> Result<(), ManagerError> {
+        let mut snapshot = query_active_topology()?;
+        let fresh_connectors = raw_path_connectors(&snapshot.raw);
+        let mut cache = self
+            .cache
+            .lock()
+            .map_err(|_| ManagerError::Backend("windows backend cache poisoned".to_string()))?;
+
+        if cache.reseed_persisted {
+            cache.reseed_persisted = false;
+            // The cache was invalidated (resume): re-seed detached-display entries from the
+            // persisted snapshot so they survive a failed enrichment. The merge already rejects
+            // snapshots with stale adapter LUIDs, preserving the point of the invalidation.
+            if let Some(persisted_raw) = load_persisted_raw_snapshot() {
+                if persisted_raw.paths.len() > snapshot.raw.paths.len() {
+                    if let Some(merged) = merge_persisted_raw_for_fresh(&snapshot, &persisted_raw) {
+                        diagnostics::log("backend_cache:reseeded_from_persisted_snapshot");
+                        snapshot = merged;
+                    }
+                }
+            }
+        }
 
         cache.last_snapshot = Some(merge_snapshot_for_cache(
             cache.last_snapshot.as_ref(),
@@ -82,8 +201,10 @@ impl WindowsDisplayBackend {
         cache.last_layout = Some(merge_layout_with_fresh(
             cache.last_layout.as_ref(),
             &snapshot.layout,
+            &fresh_connectors,
         ));
-        cache.last_displays = merge_displays_with_fresh(&cache.last_displays, &snapshot.displays);
+        cache.last_displays =
+            merge_displays_with_fresh(&cache.last_displays, &snapshot.displays, &fresh_connectors);
         Ok(())
     }
 
@@ -138,25 +259,31 @@ fn merge_snapshot_for_cache(
 }
 
 fn merge_persisted_raw_for_fresh(
-    fresh: TopologySnapshot,
+    fresh: &TopologySnapshot,
     persisted_raw: &RawTopologySnapshot,
-) -> TopologySnapshot {
-    if persisted_raw.paths.len() <= fresh.raw.paths.len() {
-        return fresh;
-    }
+) -> Option<TopologySnapshot> {
     if !raw_covers_active_outputs_raw(persisted_raw, &fresh.layout) {
-        return fresh;
+        return None;
     }
 
-    let Ok(persisted_snapshot) = snapshot_from_raw(persisted_raw.clone()) else {
-        return fresh;
-    };
+    let persisted_snapshot = snapshot_from_raw(persisted_raw.clone()).ok()?;
 
-    TopologySnapshot {
+    let fresh_connectors = raw_path_connectors(&fresh.raw);
+    Some(TopologySnapshot {
         raw: persisted_snapshot.raw,
-        layout: merge_layout_with_fresh(Some(&persisted_snapshot.layout), &fresh.layout),
-        displays: merge_displays_with_fresh(&persisted_snapshot.displays, &fresh.displays),
-    }
+        layout: merge_layout_with_fresh(
+            Some(&persisted_snapshot.layout),
+            &fresh.layout,
+            &fresh_connectors,
+        ),
+        displays: merge_displays_with_fresh(
+            &persisted_snapshot.displays,
+            &fresh.displays,
+            &fresh_connectors,
+        ),
+        // Attach candidates come from the live ALL_PATHS enumeration, never from persisted data.
+        attachable: fresh.attachable.clone(),
+    })
 }
 
 fn raw_covers_active_outputs_raw(raw: &RawTopologySnapshot, layout: &Layout) -> bool {
@@ -174,29 +301,132 @@ fn raw_covers_active_outputs_raw(raw: &RawTopologySnapshot, layout: &Layout) -> 
         })
 }
 
-fn merge_layout_with_fresh(previous: Option<&Layout>, fresh: &Layout) -> Layout {
-    let mut merged = previous.cloned().unwrap_or_else(|| fresh.clone());
-    for output in &mut merged.outputs {
-        if let Some(active) = fresh
-            .outputs
-            .iter()
-            .find(|active| active.display_id == output.display_id)
-        {
-            *output = active.clone();
-        } else {
-            output.enabled = false;
-            output.primary = false;
+fn raw_path_connectors(raw: &RawTopologySnapshot) -> HashSet<(u64, u32)> {
+    raw.paths
+        .iter()
+        .map(|path| {
+            (
+                luid_to_u64(
+                    path.targetInfo.adapterId.HighPart,
+                    path.targetInfo.adapterId.LowPart,
+                ),
+                path.targetInfo.id,
+            )
+        })
+        .collect()
+}
+
+/// A cached entry is a stale duplicate when the same physical monitor (same EDID hash) shows up
+/// in the fresh snapshot under a different (adapter_luid, target_id) AND the cached connector's
+/// path no longer exists in the fresh snapshot at all (e.g. adapter LUID churn after resume or
+/// reboot). Twin monitors with identical EDIDs are protected: both connectors keep existing.
+fn cached_id_is_stale_duplicate<'a>(
+    cached: &DisplayId,
+    mut fresh_ids: impl Iterator<Item = &'a DisplayId>,
+    fresh_connectors: &HashSet<(u64, u32)>,
+) -> bool {
+    let Some(edid_hash) = cached.edid_hash else {
+        return false;
+    };
+    let cached_connector = (cached.adapter_luid, cached.target_id);
+    if fresh_connectors.contains(&cached_connector) {
+        return false;
+    }
+    fresh_ids.any(|fresh| {
+        fresh.edid_hash == Some(edid_hash)
+            && (fresh.adapter_luid, fresh.target_id) != cached_connector
+    })
+}
+
+/// Enabled outputs of `desired` that fail to resolve against `snapshot`'s enumeration after
+/// remapping — the same criterion the manager uses before rejecting a profile/restore.
+fn unresolved_enabled_outputs(
+    desired: &Layout,
+    snapshot: &TopologySnapshot,
+) -> Vec<monarch::OutputConfig> {
+    let remapped = remap_layout_display_ids_for_snapshot(
+        desired,
+        &snapshot.layout,
+        &raw_path_connectors(&snapshot.raw),
+    );
+    let current_ids: HashSet<DisplayId> = snapshot
+        .layout
+        .outputs
+        .iter()
+        .map(|output| output.display_id.clone())
+        .collect();
+    remapped
+        .outputs
+        .into_iter()
+        .filter(|output| output.enabled && !current_ids.contains(&output.display_id))
+        .collect()
+}
+
+/// True for an inactive entry with no usable geometry: the 0x0 sentinel the ALL_PATHS seeder
+/// emits for connected-but-detached displays, whose real geometry Windows does not report.
+fn output_is_geometry_sentinel(output: &monarch::OutputConfig) -> bool {
+    !output.enabled && output.resolution.width == 0 && output.resolution.height == 0
+}
+
+fn display_is_geometry_sentinel(display: &DisplayInfo) -> bool {
+    !display.is_active && display.resolution.width == 0 && display.resolution.height == 0
+}
+
+fn merge_layout_with_fresh(
+    previous: Option<&Layout>,
+    fresh: &Layout,
+    fresh_connectors: &HashSet<(u64, u32)>,
+) -> Layout {
+    let Some(previous) = previous else {
+        return fresh.clone();
+    };
+
+    let mut outputs: Vec<monarch::OutputConfig> = Vec::new();
+    for cached in &previous.outputs {
+        if cached_id_is_stale_duplicate(
+            &cached.display_id,
+            fresh.outputs.iter().map(|output| &output.display_id),
+            fresh_connectors,
+        ) {
+            continue;
         }
+
+        let cached_connector = (cached.display_id.adapter_luid, cached.display_id.target_id);
+        let next = if let Some(active) = fresh.outputs.iter().find(|active| {
+            (active.display_id.adapter_luid, active.display_id.target_id) == cached_connector
+        }) {
+            // Same connector: the fresh data wins. Keep a known EDID hash when the fresh read
+            // transiently failed so the display identity stays stable across the glitch.
+            let mut next = active.clone();
+            if next.display_id.edid_hash.is_none() {
+                next.display_id.edid_hash = cached.display_id.edid_hash;
+            }
+            // A seeded inactive entry carries no geometry (0x0 sentinel): keep the last real
+            // geometry we knew for this connector instead of overwriting it every refresh.
+            if output_is_geometry_sentinel(&next) && !output_is_geometry_sentinel(cached) {
+                next.position = cached.position.clone();
+                next.resolution = cached.resolution.clone();
+                next.refresh_rate_mhz = cached.refresh_rate_mhz;
+            }
+            next
+        } else {
+            let mut inactive = cached.clone();
+            inactive.enabled = false;
+            inactive.primary = false;
+            inactive
+        };
+        push_output_preferring_known_edid(&mut outputs, next);
     }
     for active in &fresh.outputs {
-        if !merged
-            .outputs
-            .iter()
-            .any(|output| output.display_id == active.display_id)
-        {
-            merged.outputs.push(active.clone());
+        let connector = (active.display_id.adapter_luid, active.display_id.target_id);
+        if !outputs.iter().any(|output| {
+            (output.display_id.adapter_luid, output.display_id.target_id) == connector
+        }) {
+            outputs.push(active.clone());
         }
     }
+
+    let mut merged = Layout { outputs };
     if !merged
         .outputs
         .iter()
@@ -209,18 +439,68 @@ fn merge_layout_with_fresh(previous: Option<&Layout>, fresh: &Layout) -> Layout 
     merged
 }
 
-fn merge_displays_with_fresh(previous: &[DisplayInfo], fresh: &[DisplayInfo]) -> Vec<DisplayInfo> {
-    let mut merged = previous.to_vec();
-    for display in &mut merged {
-        if let Some(active) = fresh.iter().find(|active| active.id == display.id) {
-            *display = active.clone();
-        } else {
-            display.is_active = false;
-            display.is_primary = false;
+fn push_output_preferring_known_edid(
+    outputs: &mut Vec<monarch::OutputConfig>,
+    next: monarch::OutputConfig,
+) {
+    let connector = (next.display_id.adapter_luid, next.display_id.target_id);
+    if let Some(existing) = outputs
+        .iter_mut()
+        .find(|output| (output.display_id.adapter_luid, output.display_id.target_id) == connector)
+    {
+        if existing.display_id.edid_hash.is_none() && next.display_id.edid_hash.is_some() {
+            *existing = next;
         }
+        return;
+    }
+    outputs.push(next);
+}
+
+fn merge_displays_with_fresh(
+    previous: &[DisplayInfo],
+    fresh: &[DisplayInfo],
+    fresh_connectors: &HashSet<(u64, u32)>,
+) -> Vec<DisplayInfo> {
+    let mut merged: Vec<DisplayInfo> = Vec::new();
+    for cached in previous {
+        if cached_id_is_stale_duplicate(
+            &cached.id,
+            fresh.iter().map(|display| &display.id),
+            fresh_connectors,
+        ) {
+            continue;
+        }
+
+        let cached_connector = (cached.id.adapter_luid, cached.id.target_id);
+        let next = if let Some(active) = fresh
+            .iter()
+            .find(|active| (active.id.adapter_luid, active.id.target_id) == cached_connector)
+        {
+            let mut next = active.clone();
+            if next.id.edid_hash.is_none() {
+                next.id.edid_hash = cached.id.edid_hash;
+            }
+            // Seeded inactive entries carry the 0x0 sentinel: keep the last real geometry known
+            // for this connector so the UI does not flip to 0x0 on every refresh tick.
+            if display_is_geometry_sentinel(&next) && !display_is_geometry_sentinel(cached) {
+                next.resolution = cached.resolution.clone();
+                next.refresh_rate_mhz = cached.refresh_rate_mhz;
+            }
+            next
+        } else {
+            let mut inactive = cached.clone();
+            inactive.is_active = false;
+            inactive.is_primary = false;
+            inactive
+        };
+        push_display_preferring_known_edid(&mut merged, next);
     }
     for active in fresh {
-        if !merged.iter().any(|display| display.id == active.id) {
+        let connector = (active.id.adapter_luid, active.id.target_id);
+        if !merged
+            .iter()
+            .any(|display| (display.id.adapter_luid, display.id.target_id) == connector)
+        {
             merged.push(active.clone());
         }
     }
@@ -230,6 +510,20 @@ fn merge_displays_with_fresh(previous: &[DisplayInfo], fresh: &[DisplayInfo]) ->
             .then(left.id.target_id.cmp(&right.id.target_id))
     });
     merged
+}
+
+fn push_display_preferring_known_edid(displays: &mut Vec<DisplayInfo>, next: DisplayInfo) {
+    let connector = (next.id.adapter_luid, next.id.target_id);
+    if let Some(existing) = displays
+        .iter_mut()
+        .find(|display| (display.id.adapter_luid, display.id.target_id) == connector)
+    {
+        if existing.id.edid_hash.is_none() && next.id.edid_hash.is_some() {
+            *existing = next;
+        }
+        return;
+    }
+    displays.push(next);
 }
 
 impl DisplayBackend for WindowsDisplayBackend {
@@ -266,15 +560,18 @@ impl DisplayBackend for WindowsDisplayBackend {
         let active_snapshot = query_active_topology()?;
         let needs_attach_paths = desired_enables_inactive_output(&layout, &active_snapshot.layout);
 
-        let base_snapshot = {
+        let base_snapshot = if !needs_attach_paths {
+            // Detach-only change: apply against a minimal, non-enriched active snapshot so
+            // database-sourced paths are never fed into SetDisplayConfig (avoids spurious
+            // error-87 risks mid-detach).
+            query_active_only_topology()?
+        } else {
             let cache = self
                 .cache
                 .lock()
                 .map_err(|_| ManagerError::Backend("windows backend cache poisoned".to_string()))?;
 
-            if !needs_attach_paths {
-                active_snapshot.clone()
-            } else if let Some(cached) = cache.last_snapshot.clone() {
+            if let Some(cached) = cache.last_snapshot.clone() {
                 if raw_covers_active_outputs_raw(&cached.raw, &active_snapshot.layout) {
                     cached
                 } else {
@@ -285,28 +582,45 @@ impl DisplayBackend for WindowsDisplayBackend {
             }
         };
 
-        let working_layout = remap_layout_display_ids_for_snapshot(&layout, &base_snapshot.layout);
-        let (next_snapshot, applied_layout) =
+        let working_layout = remap_layout_display_ids_for_snapshot(
+            &layout,
+            &base_snapshot.layout,
+            &raw_path_connectors(&active_snapshot.raw),
+        );
+
+        let missing_attach_outputs =
+            enabled_outputs_missing_from_raw(&working_layout, &base_snapshot.raw);
+        let (next_snapshot, applied_layout) = if !missing_attach_outputs.is_empty() {
+            // The base snapshot has no path for these outputs, so flipping active flags would be
+            // a silent no-op (SetDisplayConfig returns 0 on an unchanged active set). Recover
+            // UNCONDITIONALLY: an "is it connected?" guard here would rely on the same
+            // enumeration that just failed to surface the display, blocking exactly the case it
+            // must cure. The cost for a genuinely absent monitor is one harmless attempt
+            // followed by the same precise error from the retry validation.
+            for output in &missing_attach_outputs {
+                diagnostics::log(format!(
+                    "recover:extend_attempt:{}",
+                    describe_output_for_error(output, &base_snapshot)
+                ));
+            }
+            recover_apply_with_topology_extend(
+                &working_layout,
+                &missing_attach_outputs,
+                &active_snapshot,
+            )?
+        } else {
             match apply_layout_against_snapshot(&working_layout, &base_snapshot) {
                 Ok(snapshot) => (snapshot, working_layout),
                 Err(error) if is_set_display_invalid_parameter(&error) => {
                     diagnostics::log("topology_apply:retry:reason=setdisplayconfig_87");
-                    force_topology_extend()?;
-                    std::thread::sleep(std::time::Duration::from_millis(700));
-                    let recovered_snapshot = query_active_topology()?;
-                    let retry_layout = remap_layout_display_ids_for_snapshot(
-                        &working_layout,
-                        &recovered_snapshot.layout,
-                    );
-                    let snapshot =
-                        apply_layout_against_snapshot(&retry_layout, &recovered_snapshot)?;
-                    (snapshot, retry_layout)
+                    recover_apply_with_topology_extend(&working_layout, &[], &active_snapshot)?
                 }
                 Err(error) => {
                     diagnostics::log(format!("topology_apply:error:{error}"));
                     return Err(error);
                 }
-            };
+            }
+        };
         let mut cache = self
             .cache
             .lock()
@@ -365,6 +679,14 @@ impl DisplayBackend for WindowsDisplayBackend {
     fn reapply_color_calibration(&self) -> Result<(), ManagerError> {
         WindowsDisplayBackend::reapply_color_calibration(self)
     }
+
+    fn invalidate_cache(&self) -> Result<(), ManagerError> {
+        WindowsDisplayBackend::invalidate_cache(self)
+    }
+
+    fn prepare_attach_targets(&self, desired: &Layout) -> Result<(), ManagerError> {
+        WindowsDisplayBackend::prepare_attach_targets(self, desired)
+    }
 }
 
 fn merge_sdr_gamma_cache(
@@ -394,7 +716,11 @@ fn desired_enables_inactive_output(desired: &Layout, active_layout: &Layout) -> 
     })
 }
 
-fn remap_layout_display_ids_for_snapshot(desired: &Layout, current: &Layout) -> Layout {
+fn remap_layout_display_ids_for_snapshot(
+    desired: &Layout,
+    current: &Layout,
+    enumerated_connectors: &HashSet<(u64, u32)>,
+) -> Layout {
     let current_ids: HashSet<DisplayId> = current
         .outputs
         .iter()
@@ -436,19 +762,21 @@ fn remap_layout_display_ids_for_snapshot(desired: &Layout, current: &Layout) -> 
                 current_by_edid.get(&edid_hash).cloned().unwrap_or_default(),
                 &used,
             );
-            if candidates.len() == 1 {
-                replacement = Some(candidates[0].display_id.clone());
-            }
+            replacement = choose_remap_candidate(&candidates, enumerated_connectors)
+                .map(|candidate| candidate.display_id.clone());
         }
 
         if replacement.is_none() && output.display_id.edid_hash.is_none() {
+            // Never guess across adapters in the hash-less fallback: iGPU/dGPU pairs reuse the
+            // same target id numbering, so a cross-adapter pick could hit the wrong monitor.
             let candidates = unique_unused_candidates_by_target_id(
                 output.display_id.target_id,
                 &current.outputs,
                 &used,
             );
-            if candidates.len() == 1 {
-                replacement = Some(candidates[0].display_id.clone());
+            if candidates_share_one_adapter(&candidates) {
+                replacement = choose_remap_candidate(&candidates, enumerated_connectors)
+                    .map(|candidate| candidate.display_id.clone());
             }
         }
 
@@ -459,6 +787,431 @@ fn remap_layout_display_ids_for_snapshot(desired: &Layout, current: &Layout) -> 
     }
 
     remapped
+}
+
+fn candidates_share_one_adapter(candidates: &[&monarch::OutputConfig]) -> bool {
+    let mut adapters = candidates
+        .iter()
+        .map(|candidate| candidate.display_id.adapter_luid);
+    let Some(first) = adapters.next() else {
+        return true;
+    };
+    adapters.all(|adapter| adapter == first)
+}
+
+fn choose_remap_candidate<'a>(
+    candidates: &[&'a monarch::OutputConfig],
+    enumerated_connectors: &HashSet<(u64, u32)>,
+) -> Option<&'a monarch::OutputConfig> {
+    if candidates.is_empty() {
+        return None;
+    }
+    if candidates.len() == 1 {
+        return Some(candidates[0]);
+    }
+
+    // Deterministic tie-break for duplicate identities (e.g. a stale cached entry plus the same
+    // physical monitor re-enumerated under a new adapter LUID after resume/reboot): prefer the
+    // candidate whose connector is currently enumerated, then the single enabled one. Two active
+    // identical twins stay ambiguous and are left unmapped.
+    let enumerated: Vec<_> = candidates
+        .iter()
+        .copied()
+        .filter(|candidate| {
+            enumerated_connectors.contains(&(
+                candidate.display_id.adapter_luid,
+                candidate.display_id.target_id,
+            ))
+        })
+        .collect();
+    if enumerated.len() == 1 {
+        return Some(enumerated[0]);
+    }
+
+    let pool = if enumerated.is_empty() {
+        candidates.to_vec()
+    } else {
+        enumerated
+    };
+    let enabled: Vec<_> = pool
+        .iter()
+        .copied()
+        .filter(|candidate| candidate.enabled)
+        .collect();
+    if enabled.len() == 1 {
+        return Some(enabled[0]);
+    }
+
+    None
+}
+
+fn enabled_outputs_missing_from_raw<'a>(
+    layout: &'a Layout,
+    raw: &RawTopologySnapshot,
+) -> Vec<&'a monarch::OutputConfig> {
+    let connectors = raw_path_connectors(raw);
+    layout
+        .outputs
+        .iter()
+        .filter(|output| output.enabled)
+        .filter(|output| {
+            !connectors.contains(&(output.display_id.adapter_luid, output.display_id.target_id))
+        })
+        .collect()
+}
+
+fn describe_output_for_error(
+    output: &monarch::OutputConfig,
+    base_snapshot: &TopologySnapshot,
+) -> String {
+    let edid = output
+        .display_id
+        .edid_hash
+        .map(|value| format!("{value:016x}"))
+        .unwrap_or_else(|| "-".to_string());
+    let friendly = base_snapshot
+        .displays
+        .iter()
+        .find(|display| {
+            display.id == output.display_id
+                || (output.display_id.edid_hash.is_some()
+                    && display.id.edid_hash == output.display_id.edid_hash)
+        })
+        .map(|display| format!("'{}' ", display.friendly_name))
+        .unwrap_or_default();
+    format!(
+        "{friendly}(target_id={}, edid_hash={edid})",
+        output.display_id.target_id
+    )
+}
+
+const RECOVER_SETTLE_DEADLINE: std::time::Duration = std::time::Duration::from_millis(3500);
+const RECOVER_SETTLE_STEP: std::time::Duration = std::time::Duration::from_millis(250);
+/// Grace window after an explicit attach Windows already accepted: it only has to cover the
+/// display's handshake, so it is much shorter than the deadline for an extend that may have to
+/// wake a target from scratch.
+const ATTACH_SETTLE_DEADLINE: std::time::Duration = std::time::Duration::from_millis(1500);
+
+/// Fill in geometry for enabled outputs that still carry the 0x0 sentinel (a display seeded from
+/// ALL_PATHS and never active on this boot) using the post-extend snapshot, where Windows has
+/// just assigned it a real source mode.
+fn fill_sentinel_geometry_from_snapshot(layout: &mut Layout, snapshot: &TopologySnapshot) {
+    for output in &mut layout.outputs {
+        if !output.enabled || output.resolution.width != 0 || output.resolution.height != 0 {
+            continue;
+        }
+        let Some(active) = snapshot
+            .layout
+            .outputs
+            .iter()
+            .find(|active| active.display_id == output.display_id)
+        else {
+            continue;
+        };
+        output.position = active.position.clone();
+        output.resolution = active.resolution.clone();
+        output.refresh_rate_mhz = active.refresh_rate_mhz;
+    }
+}
+
+/// Source keys `(source adapter luid, source id)` currently driving an active path. Attaching a
+/// target onto a busy source would clone that display instead of extending onto it.
+fn active_source_keys(snapshot: &TopologySnapshot) -> HashSet<(u64, u32)> {
+    snapshot
+        .raw
+        .paths
+        .iter()
+        .filter(|path| path.flags & DISPLAYCONFIG_PATH_ACTIVE_FLAG != 0)
+        .map(|path| {
+            (
+                luid_to_u64(
+                    path.sourceInfo.adapterId.HighPart,
+                    path.sourceInfo.adapterId.LowPart,
+                ),
+                path.sourceInfo.id,
+            )
+        })
+        .collect()
+}
+
+fn attachable_source_key(candidate: &AttachablePath) -> (u64, u32) {
+    (
+        luid_to_u64(
+            candidate.path.sourceInfo.adapterId.HighPart,
+            candidate.path.sourceInfo.adapterId.LowPart,
+        ),
+        candidate.path.sourceInfo.id,
+    )
+}
+
+/// Attach candidates for `display_id` whose source is currently free. ALL_PATHS reports one
+/// entry per (source, target) combination; picking a busy source would clone rather than extend,
+/// so those combinations are dropped rather than rewritten.
+fn select_attach_candidates<'a>(
+    attachable: &'a [AttachablePath],
+    display_id: &DisplayId,
+    used_source_keys: &HashSet<(u64, u32)>,
+) -> Vec<&'a AttachablePath> {
+    attachable
+        .iter()
+        .filter(|candidate| {
+            candidate.adapter_luid == display_id.adapter_luid
+                && candidate.target_id == display_id.target_id
+        })
+        .filter(|candidate| !used_source_keys.contains(&attachable_source_key(candidate)))
+        .collect()
+}
+
+/// Activate every still-missing enabled output in ONE SetDisplayConfig call.
+///
+/// The supplied path array is the complete topology, so a per-display call would deactivate
+/// whatever the previous call activated. Instead the batch grows one candidate at a time, each
+/// step confirmed with a free SDC_VALIDATE dry-run (alternate sources are tried when a candidate
+/// is refused), and a single apply lands at the end — one topology flip, not N.
+///
+/// Returns true only when the final apply returned 0. That still does NOT prove any display came
+/// back (SetDisplayConfig returns 0 for a no-op), so the caller must confirm against a fresh
+/// enumeration before deciding to skip the extend.
+fn try_batch_explicit_attach(
+    missing: &[&monarch::OutputConfig],
+    active_snapshot: &TopologySnapshot,
+) -> bool {
+    // Guard: the error-87 recovery path calls in with nothing missing. Without this, an empty
+    // batch would report "everything attached" and silently kill the extend fallback.
+    if missing.is_empty() {
+        return false;
+    }
+
+    let mut used_source_keys = active_source_keys(active_snapshot);
+    let mut batch: Vec<&AttachablePath> = Vec::new();
+
+    for output in missing {
+        let description = describe_output_for_error(output, active_snapshot);
+        let candidates = select_attach_candidates(
+            &active_snapshot.attachable,
+            &output.display_id,
+            &used_source_keys,
+        );
+        if candidates.is_empty() {
+            diagnostics::log(format!("recover:no_attachable_candidate:{description}"));
+            continue;
+        }
+
+        let mut accepted = false;
+        for candidate in candidates {
+            batch.push(candidate);
+            let paths = build_attach_paths(&batch, active_snapshot);
+            let status = validate_attach_paths(&paths, active_snapshot);
+            diagnostics::log(format!(
+                "recover:explicit_attach:{description}:source={}:validate={status}",
+                attachable_source_key(candidate).1
+            ));
+            if status == 0 {
+                // Claim the source so a later output in this batch cannot reuse it.
+                used_source_keys.insert(attachable_source_key(candidate));
+                accepted = true;
+                break;
+            }
+            batch.pop();
+        }
+        if !accepted {
+            diagnostics::log(format!(
+                "recover:explicit_attach:{description}:no_candidate_validated"
+            ));
+        }
+    }
+
+    if batch.is_empty() {
+        return false;
+    }
+
+    let paths = build_attach_paths(&batch, active_snapshot);
+    let status = apply_attach_paths(&paths, active_snapshot);
+    diagnostics::log(format!(
+        "recover:explicit_attach:batch={}:apply={status}",
+        batch.len()
+    ));
+    status == 0
+}
+
+/// Best-effort undo of a recovery that did not pan out. Both the explicit attach and the extend
+/// change (and persist) the topology, so leaving them in place would silently rewrite the user's
+/// setup on a failed attach. Re-applying the pre-recovery layout works because its enabled set
+/// only covers the previously active outputs, and apply's `unwrap_or(false)` disables everything
+/// the recovery added.
+fn restore_pre_extend_topology(pre_extend: &TopologySnapshot) {
+    match apply_layout_against_snapshot(&pre_extend.layout, pre_extend) {
+        Ok(_) => diagnostics::log("recover:restore_ok"),
+        Err(error) => diagnostics::log(format!("recover:restore_failed:{error}")),
+    }
+}
+
+/// The pre-recovery topology is the ONLY rollback net on a machine with no internal panel, so it
+/// is a hard precondition rather than an optional extra: capture it (with one retry, because it
+/// fails exactly when a transient QueryDisplayConfig hiccup is most likely) or do not touch the
+/// topology at all.
+fn capture_pre_recovery_state() -> Result<TopologySnapshot, ManagerError> {
+    match query_active_only_topology() {
+        Ok(snapshot) => Ok(snapshot),
+        Err(first_error) => {
+            diagnostics::log(format!(
+                "recover:pre_state_query_failed:{first_error}:retrying"
+            ));
+            std::thread::sleep(RECOVER_SETTLE_STEP);
+            query_active_only_topology()
+        }
+    }
+}
+
+enum SettleOutcome {
+    Settled(TopologySnapshot, Layout),
+    StillMissing(String),
+}
+
+/// Poll a fresh enumeration until every enabled output of `working_layout` resolves, or the
+/// deadline passes. Polling (rather than one fixed sleep) is what an HDMI/TV handshake needs,
+/// and the remap is redone on every attempt because the connector can come back under a
+/// different (adapter_luid, target_id).
+///
+/// Reports what it observed and nothing more: rollback and error wording are the caller's call.
+fn settle_poll(
+    working_layout: &Layout,
+    deadline: std::time::Duration,
+    label: &str,
+) -> Result<SettleOutcome, ManagerError> {
+    let deadline_at = std::time::Instant::now() + deadline;
+    let mut attempt = 0usize;
+    loop {
+        attempt += 1;
+        std::thread::sleep(RECOVER_SETTLE_STEP);
+        let snapshot = query_active_topology()?;
+        let layout = remap_layout_display_ids_for_snapshot(
+            working_layout,
+            &snapshot.layout,
+            &raw_path_connectors(&snapshot.raw),
+        );
+        let missing = enabled_outputs_missing_from_raw(&layout, &snapshot.raw);
+        diagnostics::log(format!(
+            "recover:settle_poll:{label}:{attempt}:missing={}",
+            missing.len()
+        ));
+        if missing.is_empty() {
+            return Ok(SettleOutcome::Settled(snapshot, layout));
+        }
+        if std::time::Instant::now() >= deadline_at {
+            return Ok(SettleOutcome::StillMissing(describe_output_for_error(
+                missing[0], &snapshot,
+            )));
+        }
+    }
+}
+
+/// Apply the desired layout once the recovery has brought every output back.
+fn finish_recovery(
+    recovered_snapshot: TopologySnapshot,
+    retry_layout: Layout,
+    pre_state: &TopologySnapshot,
+) -> Result<(TopologySnapshot, Layout), ManagerError> {
+    let mut retry_layout = retry_layout;
+    fill_sentinel_geometry_from_snapshot(&mut retry_layout, &recovered_snapshot);
+    match apply_layout_against_snapshot(&retry_layout, &recovered_snapshot) {
+        Ok(snapshot) => {
+            diagnostics::log("recover:retry_result:ok");
+            Ok((snapshot, retry_layout))
+        }
+        Err(error) => {
+            diagnostics::log(format!("recover:retry_result:{error}"));
+            restore_pre_extend_topology(pre_state);
+            Err(error)
+        }
+    }
+}
+
+fn recover_apply_with_topology_extend(
+    working_layout: &Layout,
+    missing: &[&monarch::OutputConfig],
+    active_snapshot: &TopologySnapshot,
+) -> Result<(TopologySnapshot, Layout), ManagerError> {
+    // The rollback net is a hard precondition: never touch the topology without one.
+    let pre_state = match capture_pre_recovery_state() {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            diagnostics::log("recover:abort:no_pre_state_captured");
+            return Err(error);
+        }
+    };
+
+    // Every recovery step actually attempted, so the final error can name them honestly.
+    let mut attempted: Vec<&str> = Vec::new();
+
+    // (a) Explicit attach: activates these exact targets from their own enumerated paths, the
+    // way Windows Display settings does. SDC_TOPOLOGY_EXTEND cannot substitute for it — it
+    // replays the last extended configuration from the persistence database, and a Monarch
+    // detach (saved with SDC_SAVE_TO_DATABASE) already removed this display from that entry.
+    if try_batch_explicit_attach(missing, active_snapshot) {
+        attempted.push("an explicit attach");
+        // A 0 from SetDisplayConfig only means "accepted", never "the display is back": confirm
+        // against a fresh enumeration, and keep escalating if it did not actually return.
+        match settle_poll(working_layout, ATTACH_SETTLE_DEADLINE, "attach") {
+            Ok(SettleOutcome::Settled(snapshot, layout)) => {
+                diagnostics::log("recover:resolved:explicit_attach");
+                return finish_recovery(snapshot, layout, &pre_state);
+            }
+            Ok(SettleOutcome::StillMissing(_)) => {
+                diagnostics::log("recover:attach_not_observed:escalating");
+            }
+            Err(error) => {
+                restore_pre_extend_topology(&pre_state);
+                return Err(error);
+            }
+        }
+    }
+
+    // (b) CCD topology extend. Its status cannot judge success (0 is also returned for a no-op),
+    // so the settle poll decides.
+    attempted.push("a topology extend");
+    try_topology_extend();
+    let still_missing = match settle_poll(working_layout, RECOVER_SETTLE_DEADLINE, "extend") {
+        Ok(SettleOutcome::Settled(snapshot, layout)) => {
+            diagnostics::log("recover:resolved:topology_extend");
+            return finish_recovery(snapshot, layout, &pre_state);
+        }
+        Ok(SettleOutcome::StillMissing(description)) => description,
+        Err(error) => {
+            restore_pre_extend_topology(&pre_state);
+            return Err(error);
+        }
+    };
+
+    // (c) DisplaySwitch: same shell path as Win+P, last resort.
+    diagnostics::log(format!("recover:escalate:display_switch:{still_missing}"));
+    if let Err(error) = run_display_switch_extend() {
+        diagnostics::log(format!("recover:display_switch_failed:{error}"));
+        restore_pre_extend_topology(&pre_state);
+        return Err(error);
+    }
+    attempted.push("DisplaySwitch /extend");
+
+    let still_missing = match settle_poll(working_layout, RECOVER_SETTLE_DEADLINE, "display_switch")
+    {
+        Ok(SettleOutcome::Settled(snapshot, layout)) => {
+            diagnostics::log("recover:resolved:display_switch");
+            return finish_recovery(snapshot, layout, &pre_state);
+        }
+        Ok(SettleOutcome::StillMissing(description)) => description,
+        Err(error) => {
+            restore_pre_extend_topology(&pre_state);
+            return Err(error);
+        }
+    };
+
+    // (d) Out of options: undo everything the recovery touched and name what was tried.
+    diagnostics::log(format!("recover:still_missing:{still_missing}"));
+    restore_pre_extend_topology(&pre_state);
+    Err(ManagerError::Backend(format!(
+        "cannot attach display {still_missing}: it did not come back after {}. reconnect it or attach it once from Windows Display settings",
+        attempted.join(", then ")
+    )))
 }
 
 fn unique_unused_candidates<'a>(

--- a/src-tauri/src/backend/windows/win32_types.rs
+++ b/src-tauri/src/backend/windows/win32_types.rs
@@ -9,11 +9,26 @@ pub struct RawTopologySnapshot {
     pub modes: Vec<DISPLAYCONFIG_MODE_INFO>,
 }
 
+/// A path for a connected-but-inactive target, harvested from QDC_ALL_PATHS. Kept OUT of
+/// `RawTopologySnapshot::paths` on purpose: `apply_layout_against_snapshot` feeds `raw.paths`
+/// straight to SetDisplayConfig, and these paths are candidates, not current configuration.
+/// ALL_PATHS reports one entry per (source, target) combination; every combination is kept
+/// because the source is only chosen at attach time.
+#[derive(Clone)]
+pub struct AttachablePath {
+    pub path: DISPLAYCONFIG_PATH_INFO,
+    pub adapter_luid: u64,
+    pub target_id: u32,
+}
+
 #[derive(Clone)]
 pub struct TopologySnapshot {
     pub raw: RawTopologySnapshot,
     pub layout: Layout,
     pub displays: Vec<DisplayInfo>,
+    /// Attach candidates for connected-but-detached displays; empty for snapshots rebuilt from
+    /// persisted/raw data, which carry no ALL_PATHS enumeration.
+    pub attachable: Vec<AttachablePath>,
 }
 
 pub fn luid_to_u64(high_part: i32, low_part: u32) -> u64 {

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,66 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_LOG_BYTES: u64 = 512 * 1024;
+
+fn log_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn diagnostics_log_path() -> PathBuf {
+    let config = monarch::FileConfigStore::default_config_path();
+    config
+        .parent()
+        .map(|parent| parent.join("diagnostics.log"))
+        .unwrap_or_else(|| PathBuf::from("diagnostics.log"))
+}
+
+fn diagnostics_log_backup_path() -> PathBuf {
+    let mut path = diagnostics_log_path();
+    path.set_extension("log.1");
+    path
+}
+
+fn rotate_if_needed(path: &PathBuf) {
+    let Ok(metadata) = fs::metadata(path) else {
+        return;
+    };
+    if metadata.len() < MAX_LOG_BYTES {
+        return;
+    }
+
+    let backup = diagnostics_log_backup_path();
+    let _ = fs::remove_file(&backup);
+    let _ = fs::rename(path, backup);
+}
+
+pub fn log(message: impl AsRef<str>) {
+    let _guard = match log_lock().lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+
+    let path = diagnostics_log_path();
+    if let Some(parent) = path.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+
+    rotate_if_needed(&path);
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_secs())
+        .unwrap_or(0);
+    let line = format!("[{timestamp}] {}\n", message.as_ref());
+
+    let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) else {
+        return;
+    };
+    let _ = file.write_all(line.as_bytes());
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod app;
 pub mod backend;
+pub mod diagnostics;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -12,6 +12,18 @@ pub trait DisplayBackend {
     fn reapply_color_calibration(&self) -> Result<(), ManagerError> {
         Ok(())
     }
+    /// Drop any cached display state so the next query rebuilds it from a fresh enumeration.
+    /// Backends without a cache treat this as a no-op.
+    fn invalidate_cache(&self) -> Result<(), ManagerError> {
+        Ok(())
+    }
+    /// Best-effort hook called before rejecting a layout whose enabled outputs cannot be
+    /// resolved against the current enumeration: give the backend one chance to force the
+    /// display stack to re-expose attachable targets (e.g. a topology extend on Windows).
+    /// Backends without such a mechanism treat this as a no-op.
+    fn prepare_attach_targets(&self, _desired: &Layout) -> Result<(), ManagerError> {
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -52,6 +52,8 @@ where
 {
     pub fn new(backend: B, store: S) -> Result<Self, ManagerError> {
         let mut config = store.load()?;
+        let current_layout = backend.get_layout()?;
+        let current_displays = backend.list_displays().unwrap_or_default();
         let mut should_persist = false;
         if config
             .settings
@@ -79,13 +81,22 @@ where
         let confirmation_timeout = Duration::from_secs(config.settings.revert_timeout_secs.max(1));
 
         if config.last_known_good_layout.is_none() || config.last_restorable_layout.is_none() {
-            let current_layout = backend.get_layout()?;
             if config.last_known_good_layout.is_none() {
                 config.last_known_good_layout = Some(current_layout.clone());
             }
             if config.last_restorable_layout.is_none() {
-                config.last_restorable_layout = Some(current_layout);
+                config.last_restorable_layout = Some(current_layout.clone());
             }
+            should_persist = true;
+        }
+        if sync_display_fingerprints(&mut config, &current_displays) {
+            should_persist = true;
+        }
+        if migrate_saved_layout_ids_with_fingerprints(
+            &mut config,
+            &current_layout,
+            &current_displays,
+        ) {
             should_persist = true;
         }
         if should_persist {
@@ -270,7 +281,7 @@ where
         let mut current_layout = self.backend.get_layout()?;
         normalize_primary(&mut current_layout);
         target_layout = remap_layout_display_ids(&target_layout, &current_layout);
-        ensure_any_enabled_output_resolves(&target_layout, &current_layout)?;
+        ensure_all_enabled_outputs_resolve(&target_layout, &current_layout)?;
 
         if current_layout == target_layout {
             return Ok(());
@@ -304,7 +315,7 @@ where
         normalize_primary(&mut remapped_target_layout);
         let remapped_target_layout =
             remap_layout_display_ids(&remapped_target_layout, &current_layout);
-        ensure_any_enabled_output_resolves(&remapped_target_layout, &current_layout)?;
+        ensure_all_enabled_outputs_resolve(&remapped_target_layout, &current_layout)?;
         self.backend.apply_layout(remapped_target_layout.clone())?;
         self.pending_confirmation = None;
         self.config.last_restorable_layout = Some(current_layout);
@@ -455,16 +466,177 @@ fn resolve_display_id_for_layout_action(
         }
     }
 
-    let mut matches = layout
-        .outputs
-        .iter()
-        .filter(|output| output.display_id.target_id == requested.target_id);
-    let first = matches.next()?;
-    if matches.next().is_none() {
-        return Some(first.display_id.clone());
+    if requested.edid_hash.is_none() {
+        let mut matches = layout
+            .outputs
+            .iter()
+            .filter(|output| output.display_id.target_id == requested.target_id);
+        let first = matches.next()?;
+        if matches.next().is_none() {
+            return Some(first.display_id.clone());
+        }
     }
 
     None
+}
+
+fn fingerprint_for_display(display_id: &DisplayId, friendly_name: Option<&str>) -> Option<String> {
+    let edid_hash = display_id.edid_hash?;
+    let normalized_name = friendly_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or("")
+        .to_ascii_uppercase();
+    Some(format!("{edid_hash:016x}:{normalized_name}"))
+}
+
+fn sync_display_fingerprints(config: &mut AppConfig, displays: &[DisplayInfo]) -> bool {
+    let mut changed = false;
+    for display in displays {
+        let fingerprint = fingerprint_for_display(&display.id, Some(&display.friendly_name));
+        let next = crate::model::DisplayFingerprint {
+            display_id: display.id.clone(),
+            friendly_name: display.friendly_name.clone(),
+            edid_fingerprint: fingerprint,
+        };
+
+        if let Some(existing) = config
+            .display_fingerprints
+            .iter_mut()
+            .find(|candidate| candidate.display_id == next.display_id)
+        {
+            if existing != &next {
+                *existing = next;
+                changed = true;
+            }
+        } else {
+            config.display_fingerprints.push(next);
+            changed = true;
+        }
+    }
+
+    if changed {
+        config
+            .display_fingerprints
+            .sort_by(|left, right| left.display_id.cmp(&right.display_id));
+    }
+    changed
+}
+
+fn migrate_saved_layout_ids_with_fingerprints(
+    config: &mut AppConfig,
+    current_layout: &Layout,
+    current_displays: &[DisplayInfo],
+) -> bool {
+    let mut changed = false;
+    let mut remap_profile_layout = |layout: &mut Layout| {
+        let remapped = remap_layout_display_ids_with_fingerprints(
+            layout,
+            current_layout,
+            current_displays,
+            &config.display_fingerprints,
+        );
+        if &remapped != layout {
+            *layout = remapped;
+            changed = true;
+        }
+    };
+
+    for profile in &mut config.profiles {
+        remap_profile_layout(&mut profile.layout);
+    }
+
+    if let Some(layout) = &mut config.last_known_good_layout {
+        remap_profile_layout(layout);
+    }
+    if let Some(layout) = &mut config.last_restorable_layout {
+        remap_profile_layout(layout);
+    }
+
+    changed
+}
+
+fn remap_layout_display_ids_with_fingerprints(
+    desired: &Layout,
+    current: &Layout,
+    current_displays: &[DisplayInfo],
+    fingerprints: &[crate::model::DisplayFingerprint],
+) -> Layout {
+    let mut remapped = remap_layout_display_ids(desired, current);
+    let current_ids: HashSet<DisplayId> = current
+        .outputs
+        .iter()
+        .map(|output| output.display_id.clone())
+        .collect();
+    let mut used: HashSet<DisplayId> = remapped
+        .outputs
+        .iter()
+        .filter(|output| current_ids.contains(&output.display_id))
+        .map(|output| output.display_id.clone())
+        .collect();
+
+    let friendly_by_id: HashMap<DisplayId, String> = current_displays
+        .iter()
+        .map(|display| (display.id.clone(), display.friendly_name.clone()))
+        .collect();
+    let fingerprint_by_id: HashMap<DisplayId, String> = fingerprints
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .edid_fingerprint
+                .as_ref()
+                .map(|fingerprint| (entry.display_id.clone(), fingerprint.clone()))
+        })
+        .collect();
+
+    let mut current_by_fingerprint: HashMap<String, Vec<DisplayId>> = HashMap::new();
+    for output in &current.outputs {
+        let fingerprint = fingerprint_by_id
+            .get(&output.display_id)
+            .cloned()
+            .or_else(|| {
+                let friendly = friendly_by_id.get(&output.display_id).map(String::as_str);
+                fingerprint_for_display(&output.display_id, friendly)
+            });
+        if let Some(fingerprint) = fingerprint {
+            current_by_fingerprint
+                .entry(fingerprint)
+                .or_default()
+                .push(output.display_id.clone());
+        }
+    }
+
+    for output in &mut remapped.outputs {
+        if current_ids.contains(&output.display_id) {
+            continue;
+        }
+
+        let fingerprint = fingerprint_by_id
+            .get(&output.display_id)
+            .cloned()
+            .or_else(|| fingerprint_for_display(&output.display_id, None));
+        let Some(fingerprint) = fingerprint else {
+            continue;
+        };
+        let Some(candidates) = current_by_fingerprint.get(&fingerprint) else {
+            continue;
+        };
+
+        let available: Vec<_> = candidates
+            .iter()
+            .filter(|candidate| !used.contains(*candidate))
+            .cloned()
+            .collect();
+        if available.len() != 1 {
+            continue;
+        }
+
+        let replacement = available[0].clone();
+        used.insert(replacement.clone());
+        output.display_id = replacement;
+    }
+
+    remapped
 }
 
 fn remap_layout_display_ids(desired: &Layout, current: &Layout) -> Layout {
@@ -514,7 +686,7 @@ fn remap_layout_display_ids(desired: &Layout, current: &Layout) -> Layout {
             }
         }
 
-        if replacement.is_none() {
+        if replacement.is_none() && output.display_id.edid_hash.is_none() {
             // Deterministic fallback for legacy profiles created before EDID hashes were
             // persisted: only remap by target id when there is exactly one unused candidate.
             let candidates = unique_unused_candidates_by_target_id(
@@ -536,7 +708,7 @@ fn remap_layout_display_ids(desired: &Layout, current: &Layout) -> Layout {
     remapped
 }
 
-fn ensure_any_enabled_output_resolves(
+fn ensure_all_enabled_outputs_resolve(
     desired: &Layout,
     current: &Layout,
 ) -> Result<(), ManagerError> {
@@ -546,14 +718,19 @@ fn ensure_any_enabled_output_resolves(
         .map(|output| &output.display_id)
         .collect();
 
-    let any_enabled_resolved = desired
+    if let Some(unresolved) = desired
         .outputs
         .iter()
-        .any(|output| output.enabled && current_ids.contains(&output.display_id));
-
-    if !any_enabled_resolved {
+        .find(|output| output.enabled && !current_ids.contains(&output.display_id))
+    {
+        let edid_hash = unresolved
+            .display_id
+            .edid_hash
+            .map(|value| format!("{value:016x}"))
+            .unwrap_or_else(|| "-".to_string());
         return Err(ManagerError::Validation(format!(
-            "profile/layout does not match any currently-known enabled display on this system"
+            "profile/layout references an unknown display (target_id={}, edid_hash={edid_hash}). re-save the profile on this system",
+            unresolved.display_id.target_id
         )));
     }
 
@@ -828,6 +1005,110 @@ mod tests {
             .iter()
             .all(|output| output.display_id.adapter_luid == 9));
         assert!(!manager.has_pending_confirmation());
+    }
+
+    #[test]
+    fn apply_profile_does_not_fallback_to_wrong_target_when_edid_is_known() {
+        let display_one = DisplayInfo {
+            id: DisplayId {
+                adapter_luid: 9,
+                target_id: 1,
+                edid_hash: Some(1),
+            },
+            friendly_name: "Left".to_string(),
+            is_active: true,
+            is_primary: true,
+            resolution: Resolution {
+                width: 1920,
+                height: 1080,
+            },
+            refresh_rate_mhz: 60_000,
+        };
+        let display_three_reusing_target = DisplayInfo {
+            id: DisplayId {
+                adapter_luid: 9,
+                target_id: 2,
+                edid_hash: Some(3),
+            },
+            friendly_name: "Ultrawide".to_string(),
+            is_active: false,
+            is_primary: false,
+            resolution: Resolution {
+                width: 3440,
+                height: 1440,
+            },
+            refresh_rate_mhz: 144_000,
+        };
+        let backend = MockBackend::new(
+            vec![display_one.clone(), display_three_reusing_target.clone()],
+            Layout {
+                outputs: vec![
+                    OutputConfig {
+                        display_id: display_one.id.clone(),
+                        enabled: true,
+                        position: Position { x: 0, y: 0 },
+                        resolution: display_one.resolution.clone(),
+                        refresh_rate_mhz: display_one.refresh_rate_mhz,
+                        primary: true,
+                    },
+                    OutputConfig {
+                        display_id: display_three_reusing_target.id.clone(),
+                        enabled: false,
+                        position: Position { x: 1920, y: 0 },
+                        resolution: display_three_reusing_target.resolution.clone(),
+                        refresh_rate_mhz: display_three_reusing_target.refresh_rate_mhz,
+                        primary: false,
+                    },
+                ],
+            },
+        )
+        .unwrap();
+        let store = MemoryConfigStore::new(AppConfig {
+            profiles: vec![Profile {
+                name: "work".to_string(),
+                layout: Layout {
+                    outputs: vec![
+                        OutputConfig {
+                            display_id: DisplayId {
+                                adapter_luid: 1,
+                                target_id: 1,
+                                edid_hash: Some(1),
+                            },
+                            enabled: true,
+                            position: Position { x: 0, y: 0 },
+                            resolution: Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            refresh_rate_mhz: 60_000,
+                            primary: true,
+                        },
+                        OutputConfig {
+                            display_id: DisplayId {
+                                adapter_luid: 1,
+                                target_id: 2,
+                                edid_hash: Some(2),
+                            },
+                            enabled: true,
+                            position: Position { x: 1920, y: 0 },
+                            resolution: Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            refresh_rate_mhz: 60_000,
+                            primary: false,
+                        },
+                    ],
+                },
+            }],
+            ..AppConfig::default()
+        });
+        let mut manager = MonarchDisplayManager::new(backend, store).unwrap();
+
+        let err = manager.apply_profile("work").unwrap_err();
+        assert!(
+            matches!(err, ManagerError::Validation(message) if message.contains("unknown display"))
+        );
     }
 
     #[test]

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -132,6 +132,10 @@ where
         self.backend.reapply_color_calibration()
     }
 
+    pub fn invalidate_backend_cache(&self) -> Result<(), ManagerError> {
+        self.backend.invalidate_cache()
+    }
+
     pub fn has_pending_confirmation(&self) -> bool {
         self.pending_confirmation.is_some()
     }
@@ -178,7 +182,12 @@ where
             .take()
             .ok_or(ManagerError::NoPendingConfirmation)?;
 
-        self.backend.apply_layout(pending.previous_layout.clone())?;
+        if let Err(error) = self.backend.apply_layout(pending.previous_layout.clone()) {
+            // Keep the pending confirmation when the rollback apply fails, so the state is not
+            // silently dropped: the caller can retry the rollback or confirm the current layout.
+            self.pending_confirmation = Some(pending);
+            return Err(error);
+        }
         self.config.last_known_good_layout = Some(pending.previous_layout);
         self.persist_config()
     }
@@ -278,16 +287,83 @@ where
         target_layout.ensure_valid()?;
         normalize_primary(&mut target_layout);
 
-        let mut current_layout = self.backend.get_layout()?;
-        normalize_primary(&mut current_layout);
-        target_layout = remap_layout_display_ids(&target_layout, &current_layout);
-        ensure_all_enabled_outputs_resolve(&target_layout, &current_layout)?;
+        let (target_layout, current_layout) = self.remap_and_resolve_for_apply(target_layout)?;
 
         if current_layout == target_layout {
             return Ok(());
         }
 
         self.apply_layout(target_layout)
+    }
+
+    /// Remap the desired layout onto the current enumeration and strictly validate it. An enabled
+    /// output that does not resolve names a display the backend is not enumerating at all, so
+    /// there is nothing to apply: the backend gets a chance to record why (it must not change the
+    /// topology — nothing it could do would make an absent display appear), and then the layout
+    /// is rejected with an actionable error. Attaching a display that IS enumerated but detached
+    /// needs none of this: it already resolves, and `apply_layout` attaches it.
+    fn remap_and_resolve_for_apply(
+        &self,
+        target_layout: Layout,
+    ) -> Result<(Layout, Layout), ManagerError> {
+        let mut current_layout = self.backend.get_layout()?;
+        normalize_primary(&mut current_layout);
+        let target_layout = remap_layout_display_ids(&target_layout, &current_layout);
+
+        if ensure_all_enabled_outputs_resolve(&target_layout, &current_layout).is_ok() {
+            return Ok((target_layout, current_layout));
+        }
+
+        self.backend.prepare_attach_targets(&target_layout)?;
+        let mut current_layout = self.backend.get_layout()?;
+        normalize_primary(&mut current_layout);
+        let target_layout = remap_layout_display_ids(&target_layout, &current_layout);
+        self.ensure_outputs_resolve_or_report_disconnected(&target_layout, &current_layout)?;
+        Ok((target_layout, current_layout))
+    }
+
+    fn ensure_outputs_resolve_or_report_disconnected(
+        &self,
+        desired: &Layout,
+        current: &Layout,
+    ) -> Result<(), ManagerError> {
+        let current_ids: HashSet<&DisplayId> = current
+            .outputs
+            .iter()
+            .map(|output| &output.display_id)
+            .collect();
+
+        let Some(unresolved) = desired
+            .outputs
+            .iter()
+            .find(|output| output.enabled && !current_ids.contains(&output.display_id))
+        else {
+            return Ok(());
+        };
+
+        let edid_hash = unresolved
+            .display_id
+            .edid_hash
+            .map(|value| format!("{value:016x}"))
+            .unwrap_or_else(|| "-".to_string());
+        let friendly = self
+            .backend
+            .list_displays()
+            .unwrap_or_default()
+            .into_iter()
+            .find(|display| {
+                display.id == unresolved.display_id
+                    || (unresolved.display_id.edid_hash.is_some()
+                        && display.id.edid_hash == unresolved.display_id.edid_hash)
+            })
+            .map(|display| format!("'{}' ", display.friendly_name))
+            .unwrap_or_default();
+        // This is NOT an attach failure: the display is not being enumerated at all (powered off,
+        // unplugged, or reported unavailable). Say so, instead of blaming a rescue that never ran.
+        Err(ManagerError::Validation(format!(
+            "display {friendly}(target_id={}, edid_hash={edid_hash}) is not connected right now: Windows does not report it as an available display. turn it on or reconnect it and try again, or re-save the profile without it",
+            unresolved.display_id.target_id
+        )))
     }
 
     pub fn delete_profile(&mut self, name: &str) -> Result<(), ManagerError> {
@@ -309,13 +385,11 @@ where
             .or_else(|| self.config.last_known_good_layout.clone())
             .ok_or_else(|| ManagerError::NotFound("last restorable layout".to_string()))?;
 
-        let current_layout = self.backend.get_layout()?;
         let mut remapped_target_layout = target_layout;
         remapped_target_layout.ensure_valid()?;
         normalize_primary(&mut remapped_target_layout);
-        let remapped_target_layout =
-            remap_layout_display_ids(&remapped_target_layout, &current_layout);
-        ensure_all_enabled_outputs_resolve(&remapped_target_layout, &current_layout)?;
+        let (remapped_target_layout, current_layout) =
+            self.remap_and_resolve_for_apply(remapped_target_layout)?;
         self.backend.apply_layout(remapped_target_layout.clone())?;
         self.pending_confirmation = None;
         self.config.last_restorable_layout = Some(current_layout);
@@ -681,21 +755,23 @@ fn remap_layout_display_ids(desired: &Layout, current: &Layout) -> Layout {
                 current_by_edid.get(&edid_hash).cloned().unwrap_or_default(),
                 &used,
             );
-            if candidates.len() == 1 {
-                replacement = Some(candidates[0].display_id.clone());
-            }
+            replacement =
+                choose_remap_candidate(&candidates).map(|candidate| candidate.display_id.clone());
         }
 
         if replacement.is_none() && output.display_id.edid_hash.is_none() {
             // Deterministic fallback for legacy profiles created before EDID hashes were
-            // persisted: only remap by target id when there is exactly one unused candidate.
+            // persisted: remap by target id with the same deterministic preference, but never
+            // guess across adapters (iGPU/dGPU pairs reuse the same target id numbering, so a
+            // cross-adapter pick could land on the wrong physical monitor and get persisted).
             let candidates = unique_unused_candidates_by_target_id(
                 output.display_id.target_id,
                 &current.outputs,
                 &used,
             );
-            if candidates.len() == 1 {
-                replacement = Some(candidates[0].display_id.clone());
+            if candidates_share_one_adapter(&candidates) {
+                replacement = choose_remap_candidate(&candidates)
+                    .map(|candidate| candidate.display_id.clone());
             }
         }
 
@@ -735,6 +811,41 @@ fn ensure_all_enabled_outputs_resolve(
     }
 
     Ok(())
+}
+
+fn candidates_share_one_adapter(candidates: &[&crate::model::OutputConfig]) -> bool {
+    let mut adapters = candidates
+        .iter()
+        .map(|candidate| candidate.display_id.adapter_luid);
+    let Some(first) = adapters.next() else {
+        return true;
+    };
+    adapters.all(|adapter| adapter == first)
+}
+
+fn choose_remap_candidate<'a>(
+    candidates: &[&'a crate::model::OutputConfig],
+) -> Option<&'a crate::model::OutputConfig> {
+    if candidates.is_empty() {
+        return None;
+    }
+    if candidates.len() == 1 {
+        return Some(candidates[0]);
+    }
+
+    // Deterministic tie-break for duplicate identities (e.g. a stale cached entry plus the same
+    // physical monitor re-enumerated under a new adapter LUID after resume/reboot): prefer the
+    // single enabled candidate. Two active identical twins stay ambiguous and are left unmapped.
+    let enabled: Vec<_> = candidates
+        .iter()
+        .copied()
+        .filter(|candidate| candidate.enabled)
+        .collect();
+    if enabled.len() == 1 {
+        return Some(enabled[0]);
+    }
+
+    None
 }
 
 fn unique_unused_candidates<'a>(
@@ -852,6 +963,65 @@ mod tests {
         let store = MemoryConfigStore::default();
         let manager = MonarchDisplayManager::new(backend.clone(), store.clone()).unwrap();
         (manager, backend, store)
+    }
+
+    /// Mock wrapper that counts `prepare_attach_targets` and `apply_layout` calls (the latter is
+    /// the core-visible proxy for "the topology was touched") and can simulate apply failures.
+    #[derive(Clone)]
+    struct CountingBackend {
+        inner: MockBackend,
+        prepare_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        apply_calls: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        fail_apply: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl CountingBackend {
+        fn new(inner: MockBackend) -> Self {
+            Self {
+                inner,
+                prepare_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                apply_calls: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                fail_apply: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            }
+        }
+
+        fn prepare_calls(&self) -> usize {
+            self.prepare_calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn apply_calls(&self) -> usize {
+            self.apply_calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+
+        fn set_fail_apply(&self, fail: bool) {
+            self.fail_apply
+                .store(fail, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    impl DisplayBackend for CountingBackend {
+        fn list_displays(&self) -> Result<Vec<DisplayInfo>, ManagerError> {
+            self.inner.list_displays()
+        }
+
+        fn get_layout(&self) -> Result<Layout, ManagerError> {
+            self.inner.get_layout()
+        }
+
+        fn apply_layout(&self, layout: Layout) -> Result<(), ManagerError> {
+            self.apply_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if self.fail_apply.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(ManagerError::Backend("simulated apply failure".to_string()));
+            }
+            self.inner.apply_layout(layout)
+        }
+
+        fn prepare_attach_targets(&self, _desired: &Layout) -> Result<(), ManagerError> {
+            self.prepare_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
     }
 
     #[test]
@@ -1106,9 +1276,546 @@ mod tests {
         let mut manager = MonarchDisplayManager::new(backend, store).unwrap();
 
         let err = manager.apply_profile("work").unwrap_err();
+        assert!(matches!(
+            err,
+            ManagerError::Validation(message)
+                if message.contains("is not connected right now")
+        ));
+    }
+
+    fn duplicate_edid_current_state() -> (Vec<DisplayInfo>, Layout, DisplayId, DisplayId) {
+        let primary_id = DisplayId {
+            adapter_luid: 9,
+            target_id: 1,
+            edid_hash: Some(1),
+        };
+        let stale_id = DisplayId {
+            adapter_luid: 1,
+            target_id: 2,
+            edid_hash: Some(2),
+        };
+        let fresh_id = DisplayId {
+            adapter_luid: 9,
+            target_id: 2,
+            edid_hash: Some(2),
+        };
+
+        let displays = vec![
+            DisplayInfo {
+                id: primary_id.clone(),
+                friendly_name: "Primary".to_string(),
+                is_active: true,
+                is_primary: true,
+                resolution: Resolution {
+                    width: 1920,
+                    height: 1080,
+                },
+                refresh_rate_mhz: 60_000,
+            },
+            DisplayInfo {
+                id: stale_id.clone(),
+                friendly_name: "Secondary".to_string(),
+                is_active: false,
+                is_primary: false,
+                resolution: Resolution {
+                    width: 2560,
+                    height: 1440,
+                },
+                refresh_rate_mhz: 144_000,
+            },
+            DisplayInfo {
+                id: fresh_id.clone(),
+                friendly_name: "Secondary".to_string(),
+                is_active: true,
+                is_primary: false,
+                resolution: Resolution {
+                    width: 2560,
+                    height: 1440,
+                },
+                refresh_rate_mhz: 144_000,
+            },
+        ];
+        let layout = Layout {
+            outputs: vec![
+                OutputConfig {
+                    display_id: primary_id,
+                    enabled: true,
+                    position: Position { x: 0, y: 0 },
+                    resolution: Resolution {
+                        width: 1920,
+                        height: 1080,
+                    },
+                    refresh_rate_mhz: 60_000,
+                    primary: true,
+                },
+                OutputConfig {
+                    display_id: stale_id.clone(),
+                    enabled: false,
+                    position: Position { x: 1920, y: 0 },
+                    resolution: Resolution {
+                        width: 2560,
+                        height: 1440,
+                    },
+                    refresh_rate_mhz: 144_000,
+                    primary: false,
+                },
+                OutputConfig {
+                    display_id: fresh_id.clone(),
+                    enabled: true,
+                    position: Position { x: 1920, y: 0 },
+                    resolution: Resolution {
+                        width: 2560,
+                        height: 1440,
+                    },
+                    refresh_rate_mhz: 144_000,
+                    primary: false,
+                },
+            ],
+        };
+
+        (displays, layout, stale_id, fresh_id)
+    }
+
+    fn profile_output(display_id: DisplayId, x: i32, primary: bool) -> OutputConfig {
+        OutputConfig {
+            display_id,
+            enabled: true,
+            position: Position { x, y: 0 },
+            resolution: Resolution {
+                width: 1920,
+                height: 1080,
+            },
+            refresh_rate_mhz: 60_000,
+            primary,
+        }
+    }
+
+    #[test]
+    fn apply_profile_prefers_active_candidate_among_duplicate_edid_entries() {
+        let (displays, layout, stale_id, fresh_id) = duplicate_edid_current_state();
+        let backend = MockBackend::new(displays, layout).unwrap();
+        let store = MemoryConfigStore::new(AppConfig {
+            profiles: vec![Profile {
+                name: "dual".to_string(),
+                layout: Layout {
+                    outputs: vec![
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 5,
+                                target_id: 1,
+                                edid_hash: Some(1),
+                            },
+                            0,
+                            true,
+                        ),
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 5,
+                                target_id: 2,
+                                edid_hash: Some(2),
+                            },
+                            1920,
+                            false,
+                        ),
+                    ],
+                },
+            }],
+            ..AppConfig::default()
+        });
+        let mut manager = MonarchDisplayManager::new(backend.clone(), store).unwrap();
+
+        manager.apply_profile("dual").unwrap();
+
+        let applied = backend.current_layout().unwrap();
+        let secondary = applied
+            .outputs
+            .iter()
+            .find(|output| output.display_id.edid_hash == Some(2))
+            .expect("expected remapped secondary output");
+        assert_eq!(secondary.display_id, fresh_id);
+        assert!(secondary.enabled);
+        assert!(!applied
+            .outputs
+            .iter()
+            .any(|output| output.display_id == stale_id));
+    }
+
+    #[test]
+    fn apply_profile_hashless_fallback_does_not_guess_across_adapters() {
+        // Two candidates share target_id 2 but live on different adapters (stale LUID entry vs
+        // fresh one). The hash-less fallback must not guess between them: iGPU/dGPU pairs reuse
+        // target id numbering, so a cross-adapter pick could hit the wrong physical monitor.
+        let (displays, layout, _, _) = duplicate_edid_current_state();
+        let backend = MockBackend::new(displays, layout).unwrap();
+        let store = MemoryConfigStore::new(AppConfig {
+            profiles: vec![Profile {
+                name: "legacy".to_string(),
+                layout: Layout {
+                    outputs: vec![
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 5,
+                                target_id: 1,
+                                edid_hash: None,
+                            },
+                            0,
+                            true,
+                        ),
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 5,
+                                target_id: 2,
+                                edid_hash: None,
+                            },
+                            1920,
+                            false,
+                        ),
+                    ],
+                },
+            }],
+            ..AppConfig::default()
+        });
+        let mut manager = MonarchDisplayManager::new(backend, store).unwrap();
+
+        let err = manager.apply_profile("legacy").unwrap_err();
+        assert!(matches!(
+            err,
+            ManagerError::Validation(message)
+                if message.contains("is not connected right now")
+        ));
+    }
+
+    #[test]
+    fn apply_profile_still_bails_for_two_active_twin_candidates() {
+        let primary_id = DisplayId {
+            adapter_luid: 9,
+            target_id: 1,
+            edid_hash: Some(1),
+        };
+        let twin_left_id = DisplayId {
+            adapter_luid: 9,
+            target_id: 2,
+            edid_hash: Some(7),
+        };
+        let twin_right_id = DisplayId {
+            adapter_luid: 9,
+            target_id: 3,
+            edid_hash: Some(7),
+        };
+        let twin_display = |id: &DisplayId| DisplayInfo {
+            id: id.clone(),
+            friendly_name: "Twin".to_string(),
+            is_active: true,
+            is_primary: false,
+            resolution: Resolution {
+                width: 2560,
+                height: 1440,
+            },
+            refresh_rate_mhz: 144_000,
+        };
+        let displays = vec![
+            DisplayInfo {
+                id: primary_id.clone(),
+                friendly_name: "Primary".to_string(),
+                is_active: true,
+                is_primary: true,
+                resolution: Resolution {
+                    width: 1920,
+                    height: 1080,
+                },
+                refresh_rate_mhz: 60_000,
+            },
+            twin_display(&twin_left_id),
+            twin_display(&twin_right_id),
+        ];
+        let twin_output = |id: &DisplayId, x: i32| OutputConfig {
+            display_id: id.clone(),
+            enabled: true,
+            position: Position { x, y: 0 },
+            resolution: Resolution {
+                width: 2560,
+                height: 1440,
+            },
+            refresh_rate_mhz: 144_000,
+            primary: false,
+        };
+        let layout = Layout {
+            outputs: vec![
+                OutputConfig {
+                    display_id: primary_id,
+                    enabled: true,
+                    position: Position { x: 0, y: 0 },
+                    resolution: Resolution {
+                        width: 1920,
+                        height: 1080,
+                    },
+                    refresh_rate_mhz: 60_000,
+                    primary: true,
+                },
+                twin_output(&twin_left_id, 1920),
+                twin_output(&twin_right_id, 4480),
+            ],
+        };
+        let backend = MockBackend::new(displays, layout).unwrap();
+        let store = MemoryConfigStore::new(AppConfig {
+            profiles: vec![Profile {
+                name: "twins".to_string(),
+                layout: Layout {
+                    outputs: vec![
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 5,
+                                target_id: 1,
+                                edid_hash: Some(1),
+                            },
+                            0,
+                            true,
+                        ),
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 5,
+                                target_id: 9,
+                                edid_hash: Some(7),
+                            },
+                            1920,
+                            false,
+                        ),
+                    ],
+                },
+            }],
+            ..AppConfig::default()
+        });
+        let mut manager = MonarchDisplayManager::new(backend, store).unwrap();
+
+        let err = manager.apply_profile("twins").unwrap_err();
+        assert!(matches!(
+            err,
+            ManagerError::Validation(message)
+                if message.contains("is not connected right now")
+        ));
+    }
+
+    #[test]
+    fn apply_profile_hashless_legacy_output_remaps_to_seeded_inactive_display() {
+        // Field case (Guido's TV): a legacy profile entry saved without edid_hash by an old
+        // build, while the detached TV exists only as an ALL_PATHS-seeded inactive display
+        // under the current adapter LUID. The hash-less target_id fallback must accept the
+        // seeded candidate (Some(hash) on the candidate, None on the request) and remap.
+        let primary_id = DisplayId {
+            adapter_luid: 9,
+            target_id: 1,
+            edid_hash: Some(1),
+        };
+        let seeded_tv_id = DisplayId {
+            adapter_luid: 9,
+            target_id: 4352,
+            edid_hash: Some(77),
+        };
+        let displays = vec![
+            DisplayInfo {
+                id: primary_id.clone(),
+                friendly_name: "Primary".to_string(),
+                is_active: true,
+                is_primary: true,
+                resolution: Resolution {
+                    width: 1920,
+                    height: 1080,
+                },
+                refresh_rate_mhz: 60_000,
+            },
+            DisplayInfo {
+                id: seeded_tv_id.clone(),
+                friendly_name: "TV".to_string(),
+                is_active: false,
+                is_primary: false,
+                resolution: Resolution {
+                    width: 0,
+                    height: 0,
+                },
+                refresh_rate_mhz: 60_000,
+            },
+        ];
+        let layout = Layout {
+            outputs: vec![
+                OutputConfig {
+                    display_id: primary_id,
+                    enabled: true,
+                    position: Position { x: 0, y: 0 },
+                    resolution: Resolution {
+                        width: 1920,
+                        height: 1080,
+                    },
+                    refresh_rate_mhz: 60_000,
+                    primary: true,
+                },
+                OutputConfig {
+                    display_id: seeded_tv_id.clone(),
+                    enabled: false,
+                    position: Position { x: 0, y: 0 },
+                    resolution: Resolution {
+                        width: 0,
+                        height: 0,
+                    },
+                    refresh_rate_mhz: 60_000,
+                    primary: false,
+                },
+            ],
+        };
+        let backend = MockBackend::new(displays, layout).unwrap();
+        let store = MemoryConfigStore::new(AppConfig {
+            profiles: vec![Profile {
+                name: "couch".to_string(),
+                layout: Layout {
+                    outputs: vec![
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 1,
+                                target_id: 1,
+                                edid_hash: None,
+                            },
+                            0,
+                            true,
+                        ),
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 1,
+                                target_id: 4352,
+                                edid_hash: None,
+                            },
+                            1920,
+                            false,
+                        ),
+                    ],
+                },
+            }],
+            ..AppConfig::default()
+        });
+        let mut manager = MonarchDisplayManager::new(backend.clone(), store).unwrap();
+
+        manager.apply_profile("couch").unwrap();
+
+        let applied = backend.current_layout().unwrap();
+        let tv = applied
+            .outputs
+            .iter()
+            .find(|output| output.display_id == seeded_tv_id)
+            .expect("expected TV output remapped to the seeded display");
+        assert!(tv.enabled);
+    }
+
+    #[test]
+    fn apply_profile_does_not_touch_topology_when_display_is_not_connected() {
+        // Field case: after a resume, Windows reported one of the monitors with
+        // targetAvailable=FALSE, so it was not enumerated at all. Applying a profile that wants
+        // it must NOT change the topology — the old code forced a topology extend here, which
+        // attached every connected-inactive display (including a TV the very same profile asks to
+        // detach), stalled 3.5s and failed anyway. An absent display is not an attach failure.
+        let backend =
+            CountingBackend::new(MockBackend::new(sample_displays(), sample_layout()).unwrap());
+        let store = MemoryConfigStore::new(AppConfig {
+            profiles: vec![Profile {
+                name: "PC".to_string(),
+                layout: Layout {
+                    outputs: vec![
+                        profile_output(sample_display_id(1), 0, true),
+                        // A monitor Windows is not enumerating right now.
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 1,
+                                target_id: 4353,
+                                edid_hash: Some(0xa8c7_f832_281a_39c5),
+                            },
+                            1920,
+                            false,
+                        ),
+                    ],
+                },
+            }],
+            ..AppConfig::default()
+        });
+        let mut manager = MonarchDisplayManager::new(backend.clone(), store).unwrap();
+
+        let err = manager.apply_profile("PC").unwrap_err();
         assert!(
-            matches!(err, ManagerError::Validation(message) if message.contains("unknown display"))
+            matches!(&err, ManagerError::Validation(message) if message.contains("is not connected right now")),
+            "expected the not-connected diagnosis, got: {err}"
         );
+        assert_eq!(
+            backend.apply_calls(),
+            0,
+            "an absent display must never trigger a topology change"
+        );
+        assert!(!manager.has_pending_confirmation());
+    }
+
+    #[test]
+    fn apply_profile_calls_prepare_attach_targets_when_outputs_are_unresolved() {
+        let backend =
+            CountingBackend::new(MockBackend::new(sample_displays(), sample_layout()).unwrap());
+        let store = MemoryConfigStore::new(AppConfig {
+            profiles: vec![Profile {
+                name: "ghost".to_string(),
+                layout: Layout {
+                    outputs: vec![
+                        profile_output(sample_display_id(1), 0, true),
+                        profile_output(
+                            DisplayId {
+                                adapter_luid: 1,
+                                target_id: 9,
+                                edid_hash: Some(99),
+                            },
+                            1920,
+                            false,
+                        ),
+                    ],
+                },
+            }],
+            ..AppConfig::default()
+        });
+        let mut manager = MonarchDisplayManager::new(backend.clone(), store).unwrap();
+
+        let err = manager.apply_profile("ghost").unwrap_err();
+        assert!(matches!(
+            err,
+            ManagerError::Validation(message)
+                if message.contains("is not connected right now")
+        ));
+        assert_eq!(backend.prepare_calls(), 1);
+    }
+
+    #[test]
+    fn apply_profile_does_not_call_prepare_attach_targets_when_outputs_resolve() {
+        let backend =
+            CountingBackend::new(MockBackend::new(sample_displays(), sample_layout()).unwrap());
+        let store = MemoryConfigStore::default();
+        let mut manager = MonarchDisplayManager::new(backend.clone(), store).unwrap();
+
+        manager.save_profile("dual").unwrap();
+        manager.toggle_display(&sample_display_id(2)).unwrap();
+        manager.confirm_current_layout().unwrap();
+
+        manager.apply_profile("dual").unwrap();
+
+        assert_eq!(backend.prepare_calls(), 0);
+    }
+
+    #[test]
+    fn rollback_pending_keeps_pending_when_backend_apply_fails() {
+        let backend =
+            CountingBackend::new(MockBackend::new(sample_displays(), sample_layout()).unwrap());
+        let store = MemoryConfigStore::default();
+        let mut manager = MonarchDisplayManager::new(backend.clone(), store).unwrap();
+
+        manager.toggle_display(&sample_display_id(2)).unwrap();
+        assert!(manager.has_pending_confirmation());
+
+        backend.set_fail_apply(true);
+        assert!(manager.rollback_pending().is_err());
+        assert!(manager.has_pending_confirmation());
+
+        backend.set_fail_apply(false);
+        manager.rollback_pending().unwrap();
+        assert!(!manager.has_pending_confirmation());
     }
 
     #[test]

--- a/tools/probe-sdc-flags.ps1
+++ b/tools/probe-sdc-flags.ps1
@@ -1,0 +1,63 @@
+# Probes which SetDisplayConfig flag combinations Windows accepts.
+#
+# Every call uses SDC_VALIDATE instead of SDC_APPLY, so nothing is applied and no display
+# changes: the return value is pure flag validation. Run it on any Windows machine, with any
+# number of monitors, to reproduce the results quoted in force_topology_extend (apply.rs).
+#
+#   0  = the combination is legal (and the request is satisfiable)
+#   87 = ERROR_INVALID_PARAMETER, i.e. "the combination of parameters and flags is invalid"
+#   31 = ERROR_GEN_FAILURE, i.e. flags accepted, but the driver/hardware cannot satisfy it
+#        (expected on a single-display machine: there is nothing to extend onto)
+#
+# The point of interest: 87 means the flags never reached the driver, so it is machine- and
+# driver-independent. It fails the same way everywhere.
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public static class SdcProbe {
+    [DllImport("user32.dll")]
+    public static extern int SetDisplayConfig(
+        uint numPathArrayElements, IntPtr pathArray,
+        uint numModeInfoArrayElements, IntPtr modeInfoArray,
+        uint flags);
+}
+"@
+
+$VALIDATE     = 0x40    # SDC_VALIDATE           - applies nothing
+$EXTEND       = 0x04    # SDC_TOPOLOGY_EXTEND
+$CLONE        = 0x02    # SDC_TOPOLOGY_CLONE
+$ALLOW        = 0x400   # SDC_ALLOW_CHANGES
+$SAVE_DB      = 0x200   # SDC_SAVE_TO_DATABASE
+$PERSIST      = 0x800   # SDC_PATH_PERSIST_IF_REQUIRED
+
+function Probe($label, $flags) {
+    $status = [SdcProbe]::SetDisplayConfig(0, [IntPtr]::Zero, 0, [IntPtr]::Zero, $flags)
+    $meaning = switch ($status) {
+        0     { "OK          - flags legal" }
+        87    { "ILLEGAL     - ERROR_INVALID_PARAMETER (rejected at flag validation)" }
+        31    { "flags legal - ERROR_GEN_FAILURE (driver/hardware cannot satisfy it)" }
+        1168  { "flags legal - ERROR_NOT_FOUND (no such entry in the database)" }
+        default { "status $status" }
+    }
+    "{0,-56} mask={1,-5} -> {2,-4} {3}" -f $label, $flags, $status, $meaning
+}
+
+Write-Output ""
+Write-Output "Current code in force_topology_extend:"
+Probe "VALIDATE|EXTEND|ALLOW_CHANGES|SAVE_TO_DATABASE" ($VALIDATE -bor $EXTEND -bor $ALLOW -bor $SAVE_DB)
+
+Write-Output ""
+Write-Output "Removing one flag at a time:"
+Probe "VALIDATE|EXTEND|ALLOW_CHANGES|PATH_PERSIST"     ($VALIDATE -bor $EXTEND -bor $ALLOW -bor $PERSIST)
+Probe "VALIDATE|EXTEND|ALLOW_CHANGES"                  ($VALIDATE -bor $EXTEND -bor $ALLOW)
+Probe "VALIDATE|EXTEND|PATH_PERSIST   (proposed fix)"  ($VALIDATE -bor $EXTEND -bor $PERSIST)
+Probe "VALIDATE|EXTEND"                                ($VALIDATE -bor $EXTEND)
+
+Write-Output ""
+Write-Output "SDC_ALLOW_CHANGES is the surprise - it is rejected with every SDC_TOPOLOGY_* flag,"
+Write-Output "although the docs say it 'is allowed with any other valid combination':"
+Probe "VALIDATE|CLONE|ALLOW_CHANGES"                   ($VALIDATE -bor $CLONE -bor $ALLOW)
+Probe "VALIDATE|CLONE"                                 ($VALIDATE -bor $CLONE)
+Probe "VALIDATE|CLONE|PATH_PERSIST"                    ($VALIDATE -bor $CLONE -bor $PERSIST)
+Write-Output ""


### PR DESCRIPTION
## What this does

Brings the display-recovery fixes from my personal fork upstream, as you suggested. It builds on your **PR #30** detection/diagnostics groundwork (first commit, rebased onto `main`, your authorship kept).

### Fixes
1. **Recover connected-but-detached displays.** An HDMI output that was detached (in my case a "Smart TV") would not come back on re-apply, and displays could be lost across reboots. Inactive outputs are now seeded from `QDC_ALL_PATHS` and recovery escalates **explicit attach → topology-extend → DisplaySwitch**, each dry-run-validated with `SDC_VALIDATE` and rolled back if the topology doesn't settle.
2. **Fix `force_topology_extend` flags.** It always failed with `ERROR_INVALID_PARAMETER` (87) due to an illegal `SDC_*` flag combination; replaced with a valid one. Adds `tools/probe-sdc-flags.ps1` to reproduce the flag validation with `SDC_VALIDATE`. *(This supersedes the small fix in #43.)*
3. **Unfreeze the tray after sleep/hibernate.** Startup apply moved off the main thread; a hidden window listens to `WM_POWERBROADCAST`/`WM_DISPLAYCHANGE`; external-process waits (DisplaySwitch/schtasks) are bounded; concurrent IPC handlers are capped so a relaunch can always show the window.

Related: #15, #40, #41.

### Honest status ⚠️
The display-recovery paths (#1) and the sleep fix (#3) are verified **in the field, but only on my one machine** — a 3-display desktop (2 monitors + an HDMI "Smart TV"), single GPU/driver. At runtime they're guarded by a mandatory `SDC_VALIDATE` dry-run before any real apply, and by re-enumerating to confirm results instead of trusting the `SetDisplayConfig` return code. I can't claim they're proven across drivers, and since the detached-TV path needs 3 displays it's hard to reproduce on a 2-display setup. Opened as a **draft** so CI can build it first.

Commit 1 is your own PR #30 work rebased onto `main` (your authorship kept); commit 2 is my changes.